### PR TITLE
Make ChatAgent class and its initializer public

### DIFF
--- a/Sources/LlamaStackClient/Agents/ChatAgent.swift
+++ b/Sources/LlamaStackClient/Agents/ChatAgent.swift
@@ -2,12 +2,12 @@ import Foundation
 import OpenAPIRuntime
 
 
-class ChatAgent {
+public class ChatAgent {
   private let agentConfig: Components.Schemas.AgentConfig
   private let inferenceApi: Inference
   private var sessions: [String: Components.Schemas.Session]
 
-  init(
+  public init(
     agentConfig: Components.Schemas.AgentConfig,
     inferenceApi: Inference
   ) {


### PR DESCRIPTION
I am exploring creating [RAG agents](https://llama-stack.readthedocs.io/en/latest/getting_started/index.html) and realised I need the `attachments` parameter which is available in `ChatAgent`