### PR TITLE
No more llama-stack gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "llama-stack"]
-	path = llama-stack
-	url = https://github.com/meta-llama/llama-stack

--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ let inference = RemoteInference(url: URL(string: "http://127.0.0.1:5000")!)
 
 ### Syncing the API spec
 
-Llama Stack types are generated from the OpenAPI spec in the [main repo](https://github.com/meta-llama/llama-stack). 
-That spec is synced to this repo via a git submodule and script. We'll typically take care of this and you shouldn't need to run this. 
+Llama Stack `Types.swift` file is generated from the Llama Stack [API spec](https://github.com/meta-llama/llama-stack/blob/main/docs/resources/llama-stack-spec.yaml) in the main [Llama Stack repo](https://github.com/meta-llama/llama-stack).
 
 ```
-git submodule update --init --recursive
 scripts/generate_swift_types.sh
 ```
+
+By default, this script will download the latest API spec from the main branch of the Llama Stack repo. You can set `LLAMA_STACK_DIR` to a local Llama Stack repo to use a local copy of the API spec instead.
+
+This will update the `openapi.yaml` file in the Llama Stack Swift SDK source folder `Sources/LlamaStackClient`.

--- a/scripts/generate_swift_types.sh
+++ b/scripts/generate_swift_types.sh
@@ -6,8 +6,10 @@ set -euo pipefail
 
 OPENAPI_FILE="llama-stack-spec.yaml"
 if [ -n "$LLAMA_STACK_DIR" ]; then
+  echo "Using local Llama Stack repo at $LLAMA_STACK_DIR"
   cp "$LLAMA_STACK_DIR/docs/resources/$OPENAPI_FILE" "Sources/LlamaStackClient/$OPENAPI_FILE"
 else
+  echo "Using remote (main branch) Llama Stack repo"
   URL="https://raw.githubusercontent.com/meta-llama/llama-stack/refs/heads/main/docs/resources/llama-stack-spec.yaml"
   curl -s $URL > "Sources/LlamaStackClient/$OPENAPI_FILE"
 fi

--- a/scripts/generate_swift_types.sh
+++ b/scripts/generate_swift_types.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 
+LLAMA_STACK_DIR=${LLAMA_STACK_DIR:-}
+
 set -euo pipefail
 
-cd llama-stack/
-bash ./docs/openapi_generator/run_openapi_generator.sh
-cp ./docs/resources/llama-stack-spec.yaml ../Sources/LlamaStackClient
-cd ../Sources/LlamaStackClient
-
 OPENAPI_FILE="llama-stack-spec.yaml"
+if [ -n "$LLAMA_STACK_DIR" ]; then
+  cp "$LLAMA_STACK_DIR/docs/resources/$OPENAPI_FILE" "Sources/LlamaStackClient/$OPENAPI_FILE"
+else
+  URL="https://raw.githubusercontent.com/meta-llama/llama-stack/refs/heads/main/docs/resources/llama-stack-spec.yaml"
+  curl -s $URL > "Sources/LlamaStackClient/$OPENAPI_FILE"
+fi
+
+cd Sources/LlamaStackClient
 
 # Remove security section
 sed '/^security:$/N;/\n- Default: \[\]/d' "$OPENAPI_FILE" | \


### PR DESCRIPTION
Submodules are always trouble. In this particular case, Xcode went into a spin for no reason trying to checkout llama-stack submodule. 

Simpler stuff is better.
