### PR TITLE
updated iOS Swift SDK for LS0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 llama-stack-client-swift brings the inference and agents APIs of [Llama Stack](https://github.com/meta-llama/llama-stack) to iOS.
 
-**Update: January 27, 2025** The llama-stack-client-swift SDK version has been updated to 0.1.0, working with Llama Stack 0.1.0 ([release note](https://github.com/meta-llama/llama-stack/releases/tag/v0.1.0)).
+**Update: February 18, 2025** The llama-stack-client-swift SDK version has been updated to 0.1.3, working with Llama Stack 0.1.3 ([release note](https://github.com/meta-llama/llama-stack/releases/tag/v0.1.3)).
 
 ## Features
 
@@ -21,76 +21,81 @@ For a more advanced demo using the Llama Stack Agent API and custom tool calling
 
 1. Click "Xcode > File > Add Package Dependencies...".
 
-2. Add this repo URL at the top right: `https://github.com/meta-llama/llama-stack-client-swift` and 0.1.0 in the Dependency Rule, then click Add Package.
+2. Add this repo URL at the top right: `https://github.com/meta-llama/llama-stack-client-swift` and 0.1.3 in the Dependency Rule, then click Add Package.
 
 3. Select and add `llama-stack-client-swift` to your app target.
 
 4. On the first build: Enable & Trust the OpenAPIGenerator extension when prompted.
 
-5. Set up a remote Llama Stack distributions, assuming you have a [Fireworks](https://fireworks.ai/account/api-keys) or [Together](https://api.together.ai/) API key, which you can get easily by clicking the link:
+5. The quickest way to try out the demo for remote inference is using Together.ai's Llama Stack distro at https://llama-stack.together.ai - you can skip Step 6 unless you want to build your own distro. 
+
+6. (Optional) Set up a remote Llama Stack distributions, assuming you have a [Fireworks](https://fireworks.ai/account/api-keys) or [Together](https://api.together.ai/) API key, which you can get easily by clicking the link:
 
 ```
 conda create -n llama-stack python=3.10
 conda activate llama-stack
-pip install --no-cache llama-stack==0.1.0 llama-models==0.1.0 llama-stack-client==0.1.0
+pip install --no-cache llama-stack==0.1.3 llama-models==0.1.3 llama-stack-client==0.1.3
 ```
 
 Then, either:
 ```
-PYPI_VERSION=0.1.0 llama stack build --template fireworks --image-type conda
+PYPI_VERSION=0.1.3 llama stack build --template fireworks --image-type conda
 export FIREWORKS_API_KEY="<your_fireworks_api_key>"
 llama stack run fireworks
 ```
 or
 ```
-PYPI_VERSION=0.1.0 llama stack build --template together --image-type conda
+PYPI_VERSION=0.1.3 llama stack build --template together --image-type conda
 export TOGETHER_API_KEY="<your_together_api_key>"
 llama stack run together
 ```
 
 The default port is 5000 for `llama stack run` and you can specify a different port by adding `--port <your_port>` to the end of `llama stack run fireworks|together`.
 
-6. Replace the `RemoteInference` url string below with the host IP and port of the remote Llama Stack distro in Step 5:
+Replace the `RemoteInference` url string below with the host IP and port of the remote Llama Stack distro in Step 6:
 
 ```swift
 import LlamaStackClient
 
-let inference = RemoteInference(url: URL(string: "http://127.0.0.1:5000")!)
+let inference = RemoteInference(url: URL(string: "https://llama-stack.together.ai")!)
 ```
+
+7. Build and Run the iOS demo.
+
 Below is an example code snippet to use the Llama Stack inference API. See the iOS Demos above for complete code.
 
 ```swift
 for await chunk in try await inference.chatCompletion(
     request:
         Components.Schemas.ChatCompletionRequest(
+        model_id: "meta-llama/Llama-3.1-8B-Instruct",
         messages: [
             .user(
             Components.Schemas.UserMessage(
+                role: .user,
                 content:
                     .InterleavedContentItem(
                         .text(Components.Schemas.TextContentItem(
-                            text: userInput,
-                            _type: .text
+                            _type: .text,
+                            text: userInput
                         )
                     )
-                ),
-                role: .user
+                )
             )
         )
         ],
-        model_id: "meta-llama/Llama-3.1-8B-Instruct",
         stream: true)
     ) {
         switch (chunk.event.delta) {
-            case .text(let s):
-                message += s.text
-                break
-            case .image(let s):
-                print("> \(s)")
-                break
-            case .tool_call(let s):
-                print("> \(s)")
-                break
+        case .text(let s):
+            message += s.text
+            break
+        case .image(let s):
+            print("> \(s)")
+            break
+        case .tool_call(let s):
+            print("> \(s)")
+            break
         }
     }
 ```

--- a/Sources/LlamaStackClient/Agents/ChatAgent.swift
+++ b/Sources/LlamaStackClient/Agents/ChatAgent.swift
@@ -22,8 +22,8 @@ class ChatAgent {
     let session = Components.Schemas.Session(
       session_id: sessionId,
       session_name: name,
-      started_at: Date(),
-      turns: []
+      turns: [],
+      started_at: Date()
     )
 
     sessions[sessionId] = session
@@ -82,13 +82,12 @@ class ChatAgent {
           continuation.yield(chunk)
         }
         let turn = Components.Schemas.Turn(
-          input_messages: request.messages.map { $0.toAgenticSystemTurnCreateRequest() },
-          output_attachments: [],
-          output_message: outputMessage!,
+          turn_id: turnId,
           session_id: session_id,
-          started_at: Date(),
+          input_messages: request.messages.map { $0.toAgenticSystemTurnCreateRequest() },
           steps: steps,
-          turn_id: turnId
+          output_message: outputMessage!,
+          started_at: Date()
         )
         await MainActor.run {
           var s = self.sessions[session_id]
@@ -122,10 +121,10 @@ class ChatAgent {
         do {
           for try await chunk: Components.Schemas.ChatCompletionResponseStreamChunk in try await inferenceApi.chatCompletion(
             request: Components.Schemas.ChatCompletionRequest(
-              messages: inputMessages,
               model_id: agentConfig.model,
-              stream: true,
-              tools: [] //agentConfig.client_tools
+              messages: inputMessages,
+              tools: [], //agentConfig.client_tools
+              stream: true
             )
           ) {
               continuation.yield(
@@ -134,10 +133,10 @@ class ChatAgent {
                     payload:
                         .step_progress(
                           Components.Schemas.AgentTurnResponseStepProgressPayload(
-                            delta: chunk.event.delta,
                             event_type: .step_progress,
+                            step_type: .inference,
                             step_id: UUID().uuidString,
-                            step_type: .inference
+                            delta: chunk.event.delta
                           )
                         )
                   )

--- a/Sources/LlamaStackClient/Agents/CustomTools.swift
+++ b/Sources/LlamaStackClient/Agents/CustomTools.swift
@@ -6,54 +6,53 @@ public class CustomTools {
   // for chat completion (inference) tool calling
   public class func getCreateEventTool() -> Components.Schemas.ToolDefinition {
     return Components.Schemas.ToolDefinition(
+      tool_name: Components.Schemas.ToolDefinition.tool_namePayload.case2( "create_event"),
       description: "Create a calendar event",
       parameters: Components.Schemas.ToolDefinition.parametersPayload(
         additionalProperties: [
           "event_name": Components.Schemas.ToolParamDefinition(
-            description: "The name of the meeting",
             param_type: "string",
+            description: "The name of the meeting",
             required: true
           ),
           "start": Components.Schemas.ToolParamDefinition(
-            description: "Start date in yyyy-MM-dd HH:mm format, eg. '2024-01-01 13:00'",
             param_type: "string",
+            description: "Start date in yyyy-MM-dd HH:mm format, eg. '2024-01-01 13:00'",
             required: true
           ),
           "end": Components.Schemas.ToolParamDefinition(
-            description: "End date in yyyy-MM-dd HH:mm format, eg. '2024-01-01 14:00'",
             param_type: "string",
+            description: "End date in yyyy-MM-dd HH:mm format, eg. '2024-01-01 14:00'",
             required: true
-          ),
+          )
         ]
-      ),
-      tool_name: Components.Schemas.ToolDefinition.tool_namePayload.case2( "create_event")
-
+      )
     )
   }
   
   // for agent tool calling
   public class func getCreateEventToolForAgent() -> Components.Schemas.ToolDef {
     return Components.Schemas.ToolDef(
-      description: "Create a calendar event",
-      metadata: nil,
       name: "create_event",
+      description: "Create a calendar event",
       parameters: [
         Components.Schemas.ToolParameter(
-            description: "The name of the meeting",
             name: "event_name",
             parameter_type: "string",
+            description: "The name of the meeting",
             required: true),
         Components.Schemas.ToolParameter(
-            description: "Start date in yyyy-MM-dd HH:mm format, eg. '2024-01-01 13:00'",
             name: "start",
             parameter_type: "string",
+            description: "Start date in yyyy-MM-dd HH:mm format, eg. '2024-01-01 13:00'",
             required: true),
         Components.Schemas.ToolParameter(
-            description: "End date in yyyy-MM-dd HH:mm format, eg. '2024-01-01 14:00'",
             name: "end",
             parameter_type: "string",
+            description: "End date in yyyy-MM-dd HH:mm format, eg. '2024-01-01 14:00'",
             required: true)
-      ]
+      ],
+      metadata: nil
     )
   }
 }

--- a/Sources/LlamaStackClient/Agents/LocalAgents.swift
+++ b/Sources/LlamaStackClient/Agents/LocalAgents.swift
@@ -17,12 +17,14 @@ public class LocalAgents: Agents {
     let createSystemResponse = try await create(
       request: Components.Schemas.CreateAgentRequest(
         agent_config: Components.Schemas.AgentConfig(
-          enable_session_persistence: false,
+          sampling_params: nil,
           input_shields: [],
-          instructions: "You are a helpful assistant",
-          max_infer_iters: 1,
+          output_shields: [],
+          toolgroups: [],
           model: "Meta-Llama3.1-8B-Instruct",
-          output_shields: []
+          instructions: "You are a helpful assistant"
+//          client_tools: "Meta-Llama3.1-8B-Instruct"
+          //          tool_choicesampling_paramsoutput_shieldstoolgroupsclient_toolstool_choice: []
 //          tools: [
 //            Components.Schemas.AgentConfig.toolsPayloadPayload.FunctionCallToolDefinition(
 //              CustomTools.getCreateEventTool()

--- a/Sources/LlamaStackClient/Agents/LocalAgents.swift
+++ b/Sources/LlamaStackClient/Agents/LocalAgents.swift
@@ -20,16 +20,11 @@ public class LocalAgents: Agents {
           sampling_params: nil,
           input_shields: [],
           output_shields: [],
-          toolgroups: [],
+          client_tools: [ CustomTools.getCreateEventToolForAgent() ],
+          max_infer_iters: 1, 
           model: "Meta-Llama3.1-8B-Instruct",
-          instructions: "You are a helpful assistant"
-//          client_tools: "Meta-Llama3.1-8B-Instruct"
-          //          tool_choicesampling_paramsoutput_shieldstoolgroupsclient_toolstool_choice: []
-//          tools: [
-//            Components.Schemas.AgentConfig.toolsPayloadPayload.FunctionCallToolDefinition(
-//              CustomTools.getCreateEventTool()
-//              )
-//          ]
+          instructions: "You are a helpful assistant",
+          enable_session_persistence: false
         )
       )
     )

--- a/Sources/LlamaStackClient/Agents/RemoteAgents.swift
+++ b/Sources/LlamaStackClient/Agents/RemoteAgents.swift
@@ -24,13 +24,13 @@ public class RemoteAgents: Agents {
     let createSystemResponse = try await create(
       request: Components.Schemas.CreateAgentRequest(
         agent_config: Components.Schemas.AgentConfig(
-          client_tools: [ CustomTools.getCreateEventToolForAgent() ],
-          enable_session_persistence: false,
           input_shields: ["llama_guard"],
-          instructions: "You are a helpful assistant",
+          output_shields: ["llama_guard"],
+          client_tools: [ CustomTools.getCreateEventToolForAgent() ],
           max_infer_iters: 1,
           model: "Meta-Llama3.1-8B-Instruct",
-          output_shields: ["llama_guard"]
+          instructions: "You are a helpful assistant",
+          enable_session_persistence: false
         )
       )
     )

--- a/Sources/LlamaStackClient/openapi.yaml
+++ b/Sources/LlamaStackClient/openapi.yaml
@@ -1,1714 +1,4177 @@
+openapi: 3.1.0
+info:
+  title: Llama Stack Specification
+  version: v1
+  description: >-
+    This is the specification of the Llama Stack that provides
+                    a set of endpoints and their corresponding interfaces that are
+    tailored to
+                    best leverage Llama Models.
+servers:
+  - url: http://any-hosted-llama-stack.com
+paths:
+  /v1/eval/tasks/{task_id}/evaluations:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateResponse'
+      tags:
+        - Eval
+      description: ''
+      parameters:
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprecatedEvaluateRowsRequest'
+        required: true
+      deprecated: true
+  /v1/eval-tasks/{eval_task_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Benchmark'
+      tags:
+        - Benchmarks
+      description: ''
+      parameters:
+        - name: eval_task_id
+          in: path
+          required: true
+          schema:
+            type: string
+      deprecated: true
+  /v1/eval/tasks/{task_id}/jobs/{job_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/JobStatus'
+      tags:
+        - Eval
+      description: ''
+      parameters:
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+      deprecated: true
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Eval
+      description: ''
+      parameters:
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+      deprecated: true
+  /v1/eval/tasks/{task_id}/jobs/{job_id}/result:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateResponse'
+      tags:
+        - Eval
+      description: ''
+      parameters:
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+      deprecated: true
+  /v1/eval-tasks:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListBenchmarksResponse'
+      tags:
+        - Benchmarks
+      description: ''
+      parameters: []
+      deprecated: true
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Benchmarks
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprecatedRegisterEvalTaskRequest'
+        required: true
+      deprecated: true
+  /v1/eval/tasks/{task_id}/jobs:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+      tags:
+        - Eval
+      description: ''
+      parameters:
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprecatedRunEvalRequest'
+        required: true
+      deprecated: true
+  /v1/datasetio/rows:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRowsResult'
+      tags:
+        - DatasetIO
+      description: ''
+      parameters:
+        - name: dataset_id
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: rows_in_page
+          in: query
+          required: true
+          schema:
+            type: integer
+        - name: page_token
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: filter_condition
+          in: query
+          required: false
+          schema:
+            type: string
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - DatasetIO
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppendRowsRequest'
+        required: true
+  /v1/batch-inference/chat-completion:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchChatCompletionResponse'
+      tags:
+        - BatchInference (Coming Soon)
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchChatCompletionRequest'
+        required: true
+  /v1/batch-inference/completion:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchCompletionResponse'
+      tags:
+        - BatchInference (Coming Soon)
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchCompletionRequest'
+        required: true
+  /v1/post-training/job/cancel:
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - PostTraining (Coming Soon)
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelTrainingJobRequest'
+        required: true
+  /v1/inference/chat-completion:
+    post:
+      responses:
+        '200':
+          description: >-
+            If stream=False, returns a ChatCompletionResponse with the full completion.
+            If stream=True, returns an SSE event stream of ChatCompletionResponseStreamChunk
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatCompletionResponse'
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/ChatCompletionResponseStreamChunk'
+      tags:
+        - Inference
+      description: >-
+        Generate a chat completion for the given messages using the specified model.
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatCompletionRequest'
+        required: true
+  /v1/inference/completion:
+    post:
+      responses:
+        '200':
+          description: >-
+            If stream=False, returns a CompletionResponse with the full completion.
+            If stream=True, returns an SSE event stream of CompletionResponseStreamChunk
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompletionResponse'
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/CompletionResponseStreamChunk'
+      tags:
+        - Inference
+      description: >-
+        Generate a completion for the given content using the specified model.
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompletionRequest'
+        required: true
+  /v1/agents:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentCreateResponse'
+      tags:
+        - Agents
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgentRequest'
+        required: true
+  /v1/agents/{agent_id}/session:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentSessionCreateResponse'
+      tags:
+        - Agents
+      description: ''
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgentSessionRequest'
+        required: true
+  /v1/agents/{agent_id}/session/{session_id}/turn:
+    post:
+      responses:
+        '200':
+          description: >-
+            A single turn in an interaction with an Agentic System. **OR** streamed
+            agent turn completion response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Turn'
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/AgentTurnResponseStreamChunk'
+      tags:
+        - Agents
+      description: ''
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: session_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgentTurnRequest'
+        required: true
+  /v1/agents/{agent_id}:
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Agents
+      description: ''
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/agents/{agent_id}/session/{session_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+      tags:
+        - Agents
+      description: ''
+      parameters:
+        - name: session_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: turn_ids
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Agents
+      description: ''
+      parameters:
+        - name: session_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/inference/embeddings:
+    post:
+      responses:
+        '200':
+          description: >-
+            An array of embeddings, one for each content. Each embedding is a list
+            of floats. The dimensionality of the embedding is model-specific; you
+            can check model metadata using /models/{model_id}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddingsResponse'
+      tags:
+        - Inference
+      description: >-
+        Generate embeddings for content pieces using the specified model.
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmbeddingsRequest'
+        required: true
+  /v1/eval/benchmarks/{benchmark_id}/evaluations:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateResponse'
+      tags:
+        - Eval
+      description: ''
+      parameters:
+        - name: benchmark_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvaluateRowsRequest'
+        required: true
+  /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}/step/{step_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentStepResponse'
+      tags:
+        - Agents
+      description: ''
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: session_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: turn_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: step_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Turn'
+      tags:
+        - Agents
+      description: ''
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: session_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: turn_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/eval/benchmarks/{benchmark_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Benchmark'
+      tags:
+        - Benchmarks
+      description: ''
+      parameters:
+        - name: benchmark_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/datasets/{dataset_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Dataset'
+      tags:
+        - Datasets
+      description: ''
+      parameters:
+        - name: dataset_id
+          in: path
+          required: true
+          schema:
+            type: string
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Datasets
+      description: ''
+      parameters:
+        - name: dataset_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/models/{model_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Model'
+      tags:
+        - Models
+      description: ''
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          schema:
+            type: string
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Models
+      description: ''
+      parameters:
+        - name: model_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/scoring-functions/{scoring_fn_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ScoringFn'
+      tags:
+        - ScoringFunctions
+      description: ''
+      parameters:
+        - name: scoring_fn_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/shields/{identifier}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Shield'
+      tags:
+        - Shields
+      description: ''
+      parameters:
+        - name: identifier
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/telemetry/traces/{trace_id}/spans/{span_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Span'
+      tags:
+        - Telemetry
+      description: ''
+      parameters:
+        - name: trace_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: span_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/telemetry/spans/{span_id}/tree:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuerySpanTreeResponse'
+      tags:
+        - Telemetry
+      description: ''
+      parameters:
+        - name: span_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: attributes_to_return
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: max_depth
+          in: query
+          required: false
+          schema:
+            type: integer
+  /v1/tools/{tool_name}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tool'
+      tags:
+        - ToolGroups
+      description: ''
+      parameters:
+        - name: tool_name
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/toolgroups/{toolgroup_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolGroup'
+      tags:
+        - ToolGroups
+      description: ''
+      parameters:
+        - name: toolgroup_id
+          in: path
+          required: true
+          schema:
+            type: string
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - ToolGroups
+      description: Unregister a tool group
+      parameters:
+        - name: toolgroup_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/telemetry/traces/{trace_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Trace'
+      tags:
+        - Telemetry
+      description: ''
+      parameters:
+        - name: trace_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/post-training/job/artifacts:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/PostTrainingJobArtifactsResponse'
+      tags:
+        - PostTraining (Coming Soon)
+      description: ''
+      parameters:
+        - name: job_uuid
+          in: query
+          required: true
+          schema:
+            type: string
+  /v1/post-training/job/status:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/PostTrainingJobStatusResponse'
+      tags:
+        - PostTraining (Coming Soon)
+      description: ''
+      parameters:
+        - name: job_uuid
+          in: query
+          required: true
+          schema:
+            type: string
+  /v1/post-training/jobs:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListPostTrainingJobsResponse'
+      tags:
+        - PostTraining (Coming Soon)
+      description: ''
+      parameters: []
+  /v1/vector-dbs/{vector_db_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/VectorDB'
+      tags:
+        - VectorDBs
+      description: ''
+      parameters:
+        - name: vector_db_id
+          in: path
+          required: true
+          schema:
+            type: string
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - VectorDBs
+      description: ''
+      parameters:
+        - name: vector_db_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/health:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthInfo'
+      tags:
+        - Inspect
+      description: ''
+      parameters: []
+  /v1/tool-runtime/rag-tool/insert:
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - ToolRuntime
+      description: >-
+        Index documents so they can be used by the RAG system
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InsertRequest'
+        required: true
+  /v1/vector-io/insert:
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - VectorIO
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InsertChunksRequest'
+        required: true
+  /v1/tool-runtime/invoke:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolInvocationResult'
+      tags:
+        - ToolRuntime
+      description: Run a tool with the given arguments
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvokeToolRequest'
+        required: true
+  /v1/eval/benchmarks/{benchmark_id}/jobs/{job_id}:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/JobStatus'
+      tags:
+        - Eval
+      description: ''
+      parameters:
+        - name: benchmark_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+    delete:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Eval
+      description: ''
+      parameters:
+        - name: benchmark_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/eval/benchmarks/{benchmark_id}/jobs/{job_id}/result:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateResponse'
+      tags:
+        - Eval
+      description: ''
+      parameters:
+        - name: benchmark_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/eval/benchmarks:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListBenchmarksResponse'
+      tags:
+        - Benchmarks
+      description: ''
+      parameters: []
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Benchmarks
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterBenchmarkRequest'
+        required: true
+  /v1/datasets:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListDatasetsResponse'
+      tags:
+        - Datasets
+      description: ''
+      parameters: []
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Datasets
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterDatasetRequest'
+        required: true
+  /v1/models:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListModelsResponse'
+      tags:
+        - Models
+      description: ''
+      parameters: []
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Model'
+      tags:
+        - Models
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterModelRequest'
+        required: true
+  /v1/inspect/providers:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListProvidersResponse'
+      tags:
+        - Inspect
+      description: ''
+      parameters: []
+  /v1/inspect/routes:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListRoutesResponse'
+      tags:
+        - Inspect
+      description: ''
+      parameters: []
+  /v1/tool-runtime/list-tools:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/jsonl:
+              schema:
+                $ref: '#/components/schemas/ToolDef'
+      tags:
+        - ToolRuntime
+      description: ''
+      parameters:
+        - name: tool_group_id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: mcp_endpoint
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/URL'
+  /v1/scoring-functions:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListScoringFunctionsResponse'
+      tags:
+        - ScoringFunctions
+      description: ''
+      parameters: []
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - ScoringFunctions
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterScoringFunctionRequest'
+        required: true
+  /v1/shields:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListShieldsResponse'
+      tags:
+        - Shields
+      description: ''
+      parameters: []
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Shield'
+      tags:
+        - Shields
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterShieldRequest'
+        required: true
+  /v1/toolgroups:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListToolGroupsResponse'
+      tags:
+        - ToolGroups
+      description: List tool groups with optional provider
+      parameters: []
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - ToolGroups
+      description: Register a tool group
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterToolGroupRequest'
+        required: true
+  /v1/tools:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListToolsResponse'
+      tags:
+        - ToolGroups
+      description: List tools with optional tool group
+      parameters:
+        - name: toolgroup_id
+          in: query
+          required: false
+          schema:
+            type: string
+  /v1/vector-dbs:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListVectorDBsResponse'
+      tags:
+        - VectorDBs
+      description: ''
+      parameters: []
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorDB'
+      tags:
+        - VectorDBs
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterVectorDbRequest'
+        required: true
+  /v1/telemetry/events:
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Telemetry
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogEventRequest'
+        required: true
+  /v1/post-training/preference-optimize:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostTrainingJob'
+      tags:
+        - PostTraining (Coming Soon)
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreferenceOptimizeRequest'
+        required: true
+  /v1/tool-runtime/rag-tool/query:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RAGQueryResult'
+      tags:
+        - ToolRuntime
+      description: >-
+        Query the RAG system for context; typically invoked by the agent
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryRequest'
+        required: true
+  /v1/vector-io/query:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryChunksResponse'
+      tags:
+        - VectorIO
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryChunksRequest'
+        required: true
+  /v1/telemetry/spans:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuerySpansResponse'
+      tags:
+        - Telemetry
+      description: ''
+      parameters:
+        - name: attribute_filters
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/QueryCondition'
+        - name: attributes_to_return
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: max_depth
+          in: query
+          required: false
+          schema:
+            type: integer
+  /v1/telemetry/traces:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryTracesResponse'
+      tags:
+        - Telemetry
+      description: ''
+      parameters:
+        - name: attribute_filters
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/QueryCondition'
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: order_by
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+  /v1/eval/benchmarks/{benchmark_id}/jobs:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+      tags:
+        - Eval
+      description: ''
+      parameters:
+        - name: benchmark_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunEvalRequest'
+        required: true
+  /v1/safety/run-shield:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunShieldResponse'
+      tags:
+        - Safety
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunShieldRequest'
+        required: true
+  /v1/telemetry/spans/export:
+    post:
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Telemetry
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SaveSpansToDatasetRequest'
+        required: true
+  /v1/scoring/score:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScoreResponse'
+      tags:
+        - Scoring
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScoreRequest'
+        required: true
+  /v1/scoring/score-batch:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScoreBatchResponse'
+      tags:
+        - Scoring
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScoreBatchRequest'
+        required: true
+  /v1/post-training/supervised-fine-tune:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostTrainingJob'
+      tags:
+        - PostTraining (Coming Soon)
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SupervisedFineTuneRequest'
+        required: true
+  /v1/synthetic-data-generation/generate:
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyntheticDataGenerationResponse'
+      tags:
+        - SyntheticDataGeneration (Coming Soon)
+      description: ''
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyntheticDataGenerateRequest'
+        required: true
+  /v1/version:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionInfo'
+      tags:
+        - Inspect
+      description: ''
+      parameters: []
+jsonSchemaDialect: >-
+  https://json-schema.org/draft/2020-12/schema
 components:
-  responses: {}
   schemas:
     AgentCandidate:
-      additionalProperties: false
+      type: object
       properties:
-        config:
-          $ref: '#/components/schemas/AgentConfig'
         type:
+          type: string
           const: agent
           default: agent
-          type: string
-      required:
-      - type
-      - config
-      type: object
-    AgentConfig:
+        config:
+          $ref: '#/components/schemas/AgentConfig'
       additionalProperties: false
+      required:
+        - type
+        - config
+    AgentConfig:
+      type: object
       properties:
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+        input_shields:
+          type: array
+          items:
+            type: string
+        output_shields:
+          type: array
+          items:
+            type: string
+        toolgroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentTool'
         client_tools:
+          type: array
           items:
             $ref: '#/components/schemas/ToolDef'
-          type: array
-        enable_session_persistence:
-          type: boolean
-        input_shields:
-          items:
-            type: string
-          type: array
+        tool_choice:
+          type: string
+          enum:
+            - auto
+            - required
+          description: >-
+            Whether tool use is required or automatic. This is a hint to the model
+            which may not be followed. It depends on the Instruction Following capabilities
+            of the model.
+        tool_prompt_format:
+          type: string
+          enum:
+            - json
+            - function_tag
+            - python_list
+          description: >-
+            Prompt format for calling custom / zero shot tools.
+        tool_config:
+          $ref: '#/components/schemas/ToolConfig'
+        max_infer_iters:
+          type: integer
+          default: 10
+        model:
+          type: string
         instructions:
           type: string
-        max_infer_iters:
-          default: 10
-          type: integer
-        model:
-          type: string
-        output_shields:
-          items:
-            type: string
-          type: array
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-        tool_choice:
-          $ref: '#/components/schemas/ToolChoice'
-          default: auto
-        tool_prompt_format:
-          $ref: '#/components/schemas/ToolPromptFormat'
-        toolgroups:
-          items:
-            $ref: '#/components/schemas/AgentTool'
-          type: array
-      required:
-      - max_infer_iters
-      - model
-      - instructions
-      - enable_session_persistence
-      type: object
-    AgentCreateResponse:
+        enable_session_persistence:
+          type: boolean
+          default: false
+        response_format:
+          $ref: '#/components/schemas/ResponseFormat'
       additionalProperties: false
-      properties:
-        agent_id:
-          type: string
       required:
-      - agent_id
-      type: object
-    AgentSessionCreateResponse:
-      additionalProperties: false
-      properties:
-        session_id:
-          type: string
-      required:
-      - session_id
-      type: object
-    AgentStepResponse:
-      additionalProperties: false
-      properties:
-        step:
-          discriminator:
-            mapping:
-              inference: '#/components/schemas/InferenceStep'
-              memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
-              shield_call: '#/components/schemas/ShieldCallStep'
-              tool_execution: '#/components/schemas/ToolExecutionStep'
-            propertyName: step_type
-          oneOf:
-          - $ref: '#/components/schemas/InferenceStep'
-          - $ref: '#/components/schemas/ToolExecutionStep'
-          - $ref: '#/components/schemas/ShieldCallStep'
-          - $ref: '#/components/schemas/MemoryRetrievalStep'
-      required:
-      - step
-      type: object
+        - model
+        - instructions
     AgentTool:
       oneOf:
-      - type: string
-      - additionalProperties: false
-        properties:
-          args:
-            additionalProperties:
-              oneOf:
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          name:
-            type: string
-        required:
-        - name
-        - args
-        type: object
-    AgentTurnInputType:
-      additionalProperties: false
-      properties:
-        type:
-          const: agent_turn_input
-          default: agent_turn_input
-          type: string
-      required:
-      - type
-      type: object
-    AgentTurnResponseEvent:
-      additionalProperties: false
-      properties:
-        payload:
-          discriminator:
-            mapping:
-              step_complete: '#/components/schemas/AgentTurnResponseStepCompletePayload'
-              step_progress: '#/components/schemas/AgentTurnResponseStepProgressPayload'
-              step_start: '#/components/schemas/AgentTurnResponseStepStartPayload'
-              turn_complete: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
-              turn_start: '#/components/schemas/AgentTurnResponseTurnStartPayload'
-            propertyName: event_type
-          oneOf:
-          - $ref: '#/components/schemas/AgentTurnResponseStepStartPayload'
-          - $ref: '#/components/schemas/AgentTurnResponseStepProgressPayload'
-          - $ref: '#/components/schemas/AgentTurnResponseStepCompletePayload'
-          - $ref: '#/components/schemas/AgentTurnResponseTurnStartPayload'
-          - $ref: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
-      required:
-      - payload
-      title: Streamed agent execution response.
-      type: object
-    AgentTurnResponseStepCompletePayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: step_complete
-          default: step_complete
-          type: string
-        step_details:
-          discriminator:
-            mapping:
-              inference: '#/components/schemas/InferenceStep'
-              memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
-              shield_call: '#/components/schemas/ShieldCallStep'
-              tool_execution: '#/components/schemas/ToolExecutionStep'
-            propertyName: step_type
-          oneOf:
-          - $ref: '#/components/schemas/InferenceStep'
-          - $ref: '#/components/schemas/ToolExecutionStep'
-          - $ref: '#/components/schemas/ShieldCallStep'
-          - $ref: '#/components/schemas/MemoryRetrievalStep'
-        step_id:
-          type: string
-        step_type:
-          enum:
-          - inference
-          - tool_execution
-          - shield_call
-          - memory_retrieval
-          type: string
-      required:
-      - event_type
-      - step_type
-      - step_id
-      - step_details
-      type: object
-    AgentTurnResponseStepProgressPayload:
-      additionalProperties: false
-      properties:
-        delta:
-          $ref: '#/components/schemas/ContentDelta'
-        event_type:
-          const: step_progress
-          default: step_progress
-          type: string
-        step_id:
-          type: string
-        step_type:
-          enum:
-          - inference
-          - tool_execution
-          - shield_call
-          - memory_retrieval
-          type: string
-      required:
-      - event_type
-      - step_type
-      - step_id
-      - delta
-      type: object
-    AgentTurnResponseStepStartPayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: step_start
-          default: step_start
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        step_id:
-          type: string
-        step_type:
-          enum:
-          - inference
-          - tool_execution
-          - shield_call
-          - memory_retrieval
-          type: string
-      required:
-      - event_type
-      - step_type
-      - step_id
-      type: object
-    AgentTurnResponseStreamChunk:
-      additionalProperties: false
-      properties:
-        event:
-          $ref: '#/components/schemas/AgentTurnResponseEvent'
-      required:
-      - event
-      title: streamed agent turn completion response.
-      type: object
-    AgentTurnResponseTurnCompletePayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: turn_complete
-          default: turn_complete
-          type: string
-        turn:
-          $ref: '#/components/schemas/Turn'
-      required:
-      - event_type
-      - turn
-      type: object
-    AgentTurnResponseTurnStartPayload:
-      additionalProperties: false
-      properties:
-        event_type:
-          const: turn_start
-          default: turn_start
-          type: string
-        turn_id:
-          type: string
-      required:
-      - event_type
-      - turn_id
-      type: object
-    AggregationFunctionType:
-      enum:
-      - average
-      - median
-      - categorical_count
-      - accuracy
-      type: string
-    AppEvalTaskConfig:
-      additionalProperties: false
-      properties:
-        eval_candidate:
-          discriminator:
-            mapping:
-              agent: '#/components/schemas/AgentCandidate'
-              model: '#/components/schemas/ModelCandidate'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/ModelCandidate'
-          - $ref: '#/components/schemas/AgentCandidate'
-        num_examples:
-          type: integer
-        scoring_params:
-          additionalProperties:
-            discriminator:
-              mapping:
-                basic: '#/components/schemas/BasicScoringFnParams'
-                llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-                regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-              propertyName: type
-            oneOf:
-            - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-            - $ref: '#/components/schemas/RegexParserScoringFnParams'
-            - $ref: '#/components/schemas/BasicScoringFnParams'
-          type: object
-        type:
-          const: app
-          default: app
-          type: string
-      required:
-      - type
-      - eval_candidate
-      - scoring_params
-      type: object
-    AppendRowsRequest:
-      additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        rows:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
-      required:
-      - dataset_id
-      - rows
-      type: object
-    ArrayType:
-      additionalProperties: false
-      properties:
-        type:
-          const: array
-          default: array
-          type: string
-      required:
-      - type
-      type: object
-    BasicScoringFnParams:
-      additionalProperties: false
-      properties:
-        aggregation_functions:
-          items:
-            $ref: '#/components/schemas/AggregationFunctionType'
-          type: array
-        type:
-          const: basic
-          default: basic
-          type: string
-      required:
-      - type
-      type: object
-    BatchChatCompletionRequest:
-      additionalProperties: false
-      properties:
-        logprobs:
-          additionalProperties: false
+        - type: string
+        - type: object
           properties:
-            top_k:
-              default: 0
-              type: integer
-          type: object
-        messages_batch:
-          items:
-            items:
-              $ref: '#/components/schemas/Message'
-            type: array
-          type: array
-        model:
-          type: string
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-        tool_choice:
-          $ref: '#/components/schemas/ToolChoice'
-        tool_prompt_format:
-          $ref: '#/components/schemas/ToolPromptFormat'
-        tools:
-          items:
-            $ref: '#/components/schemas/ToolDefinition'
-          type: array
-      required:
-      - model
-      - messages_batch
-      type: object
-    BatchChatCompletionResponse:
-      additionalProperties: false
-      properties:
-        completion_message_batch:
-          items:
-            $ref: '#/components/schemas/CompletionMessage'
-          type: array
-      required:
-      - completion_message_batch
-      type: object
-    BatchCompletionRequest:
-      additionalProperties: false
-      properties:
-        content_batch:
-          items:
-            $ref: '#/components/schemas/InterleavedContent'
-          type: array
-        logprobs:
-          additionalProperties: false
-          properties:
-            top_k:
-              default: 0
-              type: integer
-          type: object
-        model:
-          type: string
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-      required:
-      - model
-      - content_batch
-      type: object
-    BatchCompletionResponse:
-      additionalProperties: false
-      properties:
-        completion_message_batch:
-          items:
-            $ref: '#/components/schemas/CompletionMessage'
-          type: array
-      required:
-      - completion_message_batch
-      type: object
-    BenchmarkEvalTaskConfig:
-      additionalProperties: false
-      properties:
-        eval_candidate:
-          discriminator:
-            mapping:
-              agent: '#/components/schemas/AgentCandidate'
-              model: '#/components/schemas/ModelCandidate'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/ModelCandidate'
-          - $ref: '#/components/schemas/AgentCandidate'
-        num_examples:
-          type: integer
-        type:
-          const: benchmark
-          default: benchmark
-          type: string
-      required:
-      - type
-      - eval_candidate
-      type: object
-    BooleanType:
-      additionalProperties: false
-      properties:
-        type:
-          const: boolean
-          default: boolean
-          type: string
-      required:
-      - type
-      type: object
-    BuiltinTool:
-      enum:
-      - brave_search
-      - wolfram_alpha
-      - photogen
-      - code_interpreter
-      type: string
-    CancelTrainingJobRequest:
-      additionalProperties: false
-      properties:
-        job_uuid:
-          type: string
-      required:
-      - job_uuid
-      type: object
-    ChatCompletionInputType:
-      additionalProperties: false
-      properties:
-        type:
-          const: chat_completion_input
-          default: chat_completion_input
-          type: string
-      required:
-      - type
-      type: object
-    ChatCompletionRequest:
-      additionalProperties: false
-      properties:
-        logprobs:
-          additionalProperties: false
-          properties:
-            top_k:
-              default: 0
-              type: integer
-          type: object
-        messages:
-          items:
-            $ref: '#/components/schemas/Message'
-          type: array
-        model_id:
-          type: string
-        response_format:
-          $ref: '#/components/schemas/ResponseFormat'
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-        stream:
-          type: boolean
-        tool_choice:
-          $ref: '#/components/schemas/ToolChoice'
-        tool_prompt_format:
-          $ref: '#/components/schemas/ToolPromptFormat'
-        tools:
-          items:
-            $ref: '#/components/schemas/ToolDefinition'
-          type: array
-      required:
-      - model_id
-      - messages
-      type: object
-    ChatCompletionResponse:
-      additionalProperties: false
-      properties:
-        completion_message:
-          $ref: '#/components/schemas/CompletionMessage'
-        logprobs:
-          items:
-            $ref: '#/components/schemas/TokenLogProbs'
-          type: array
-      required:
-      - completion_message
-      title: Chat completion response.
-      type: object
-    ChatCompletionResponseEvent:
-      additionalProperties: false
-      properties:
-        delta:
-          $ref: '#/components/schemas/ContentDelta'
-        event_type:
-          $ref: '#/components/schemas/ChatCompletionResponseEventType'
-        logprobs:
-          items:
-            $ref: '#/components/schemas/TokenLogProbs'
-          type: array
-        stop_reason:
-          $ref: '#/components/schemas/StopReason'
-      required:
-      - event_type
-      - delta
-      title: Chat completion response event.
-      type: object
-    ChatCompletionResponseEventType:
-      enum:
-      - start
-      - complete
-      - progress
-      type: string
-    ChatCompletionResponseStreamChunk:
-      additionalProperties: false
-      properties:
-        event:
-          $ref: '#/components/schemas/ChatCompletionResponseEvent'
-      required:
-      - event
-      title: SSE-stream of these events.
-      type: object
-    Checkpoint:
-      description: Checkpoint created during training runs
-    CompletionInputType:
-      additionalProperties: false
-      properties:
-        type:
-          const: completion_input
-          default: completion_input
-          type: string
-      required:
-      - type
-      type: object
-    CompletionMessage:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        role:
-          const: assistant
-          default: assistant
-          type: string
-        stop_reason:
-          $ref: '#/components/schemas/StopReason'
-        tool_calls:
-          items:
-            $ref: '#/components/schemas/ToolCall'
-          type: array
-      required:
-      - role
-      - content
-      - stop_reason
-      - tool_calls
-      type: object
-    CompletionRequest:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        logprobs:
-          additionalProperties: false
-          properties:
-            top_k:
-              default: 0
-              type: integer
-          type: object
-        model_id:
-          type: string
-        response_format:
-          $ref: '#/components/schemas/ResponseFormat'
-        sampling_params:
-          $ref: '#/components/schemas/SamplingParams'
-        stream:
-          type: boolean
-      required:
-      - model_id
-      - content
-      type: object
-    CompletionResponse:
-      additionalProperties: false
-      properties:
-        content:
-          type: string
-        logprobs:
-          items:
-            $ref: '#/components/schemas/TokenLogProbs'
-          type: array
-        stop_reason:
-          $ref: '#/components/schemas/StopReason'
-      required:
-      - content
-      - stop_reason
-      title: Completion response.
-      type: object
-    CompletionResponseStreamChunk:
-      additionalProperties: false
-      properties:
-        delta:
-          type: string
-        logprobs:
-          items:
-            $ref: '#/components/schemas/TokenLogProbs'
-          type: array
-        stop_reason:
-          $ref: '#/components/schemas/StopReason'
-      required:
-      - delta
-      title: streamed completion response.
-      type: object
-    ContentDelta:
-      discriminator:
-        mapping:
-          image: '#/components/schemas/ImageDelta'
-          text: '#/components/schemas/TextDelta'
-          tool_call: '#/components/schemas/ToolCallDelta'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/TextDelta'
-      - $ref: '#/components/schemas/ImageDelta'
-      - $ref: '#/components/schemas/ToolCallDelta'
-    CreateAgentRequest:
-      additionalProperties: false
-      properties:
-        agent_config:
-          $ref: '#/components/schemas/AgentConfig'
-      required:
-      - agent_config
-      type: object
-    CreateAgentSessionRequest:
-      additionalProperties: false
-      properties:
-        session_name:
-          type: string
-      required:
-      - session_name
-      type: object
-    CreateAgentTurnRequest:
-      additionalProperties: false
-      properties:
-        documents:
-          items:
-            additionalProperties: false
-            properties:
-              content:
-                oneOf:
-                - type: string
-                - $ref: '#/components/schemas/InterleavedContentItem'
-                - items:
-                    $ref: '#/components/schemas/InterleavedContentItem'
-                  type: array
-                - $ref: '#/components/schemas/URL'
-              mime_type:
-                type: string
-            required:
-            - content
-            - mime_type
-            type: object
-          type: array
-        messages:
-          items:
-            oneOf:
-            - $ref: '#/components/schemas/UserMessage'
-            - $ref: '#/components/schemas/ToolResponseMessage'
-          type: array
-        stream:
-          type: boolean
-        toolgroups:
-          items:
-            $ref: '#/components/schemas/AgentTool'
-          type: array
-      required:
-      - messages
-      type: object
-    DPOAlignmentConfig:
-      additionalProperties: false
-      properties:
-        epsilon:
-          type: number
-        gamma:
-          type: number
-        reward_clip:
-          type: number
-        reward_scale:
-          type: number
-      required:
-      - reward_scale
-      - reward_clip
-      - epsilon
-      - gamma
-      type: object
-    DataConfig:
-      additionalProperties: false
-      properties:
-        batch_size:
-          type: integer
-        data_format:
-          $ref: '#/components/schemas/DatasetFormat'
-        dataset_id:
-          type: string
-        packed:
-          default: false
-          type: boolean
-        shuffle:
-          type: boolean
-        train_on_input:
-          default: false
-          type: boolean
-        validation_dataset_id:
-          type: string
-      required:
-      - dataset_id
-      - batch_size
-      - shuffle
-      - data_format
-      type: object
-    Dataset:
-      additionalProperties: false
-      properties:
-        dataset_schema:
-          additionalProperties:
-            $ref: '#/components/schemas/ParamType'
-          type: object
-        identifier:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        type:
-          const: dataset
-          default: dataset
-          type: string
-        url:
-          $ref: '#/components/schemas/URL'
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - dataset_schema
-      - url
-      - metadata
-      type: object
-    DatasetFormat:
-      enum:
-      - instruct
-      - dialog
-      type: string
-    DefaultRAGQueryGeneratorConfig:
-      additionalProperties: false
-      properties:
-        separator:
-          default: ' '
-          type: string
-        type:
-          const: default
-          default: default
-          type: string
-      required:
-      - type
-      - separator
-      type: object
-    EfficiencyConfig:
-      additionalProperties: false
-      properties:
-        enable_activation_checkpointing:
-          default: false
-          type: boolean
-        enable_activation_offloading:
-          default: false
-          type: boolean
-        fsdp_cpu_offload:
-          default: false
-          type: boolean
-        memory_efficient_fsdp_wrap:
-          default: false
-          type: boolean
-      type: object
-    EmbeddingsRequest:
-      additionalProperties: false
-      properties:
-        contents:
-          items:
-            $ref: '#/components/schemas/InterleavedContent'
-          type: array
-        model_id:
-          type: string
-      required:
-      - model_id
-      - contents
-      type: object
-    EmbeddingsResponse:
-      additionalProperties: false
-      properties:
-        embeddings:
-          items:
-            items:
-              type: number
-            type: array
-          type: array
-      required:
-      - embeddings
-      type: object
-    EvalTask:
-      additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        identifier:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        scoring_functions:
-          items:
-            type: string
-          type: array
-        type:
-          const: eval_task
-          default: eval_task
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - dataset_id
-      - scoring_functions
-      - metadata
-      type: object
-    EvaluateResponse:
-      additionalProperties: false
-      properties:
-        generations:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
-        scores:
-          additionalProperties:
-            $ref: '#/components/schemas/ScoringResult'
-          type: object
-      required:
-      - generations
-      - scores
-      type: object
-    EvaluateRowsRequest:
-      additionalProperties: false
-      properties:
-        input_rows:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
-        scoring_functions:
-          items:
-            type: string
-          type: array
-        task_config:
-          discriminator:
-            mapping:
-              app: '#/components/schemas/AppEvalTaskConfig'
-              benchmark: '#/components/schemas/BenchmarkEvalTaskConfig'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/BenchmarkEvalTaskConfig'
-          - $ref: '#/components/schemas/AppEvalTaskConfig'
-      required:
-      - input_rows
-      - scoring_functions
-      - task_config
-      type: object
-    GrammarResponseFormat:
-      additionalProperties: false
-      properties:
-        bnf:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        type:
-          const: grammar
-          default: grammar
-          type: string
-      required:
-      - type
-      - bnf
-      type: object
-    GreedySamplingStrategy:
-      additionalProperties: false
-      properties:
-        type:
-          const: greedy
-          default: greedy
-          type: string
-      required:
-      - type
-      type: object
-    HealthInfo:
-      additionalProperties: false
-      properties:
-        status:
-          type: string
-      required:
-      - status
-      type: object
-    ImageContentItem:
-      additionalProperties: false
-      properties:
-        image:
-          additionalProperties: false
-          properties:
-            data:
-              contentEncoding: base64
+            name:
               type: string
-            url:
-              $ref: '#/components/schemas/URL'
-          type: object
-        type:
-          const: image
-          default: image
-          type: string
-      required:
-      - type
-      - image
-      type: object
-    ImageDelta:
-      additionalProperties: false
-      properties:
-        image:
-          contentEncoding: base64
-          type: string
-        type:
-          const: image
-          default: image
-          type: string
-      required:
-      - type
-      - image
-      type: object
-    InferenceStep:
-      additionalProperties: false
-      properties:
-        completed_at:
-          format: date-time
-          type: string
-        model_response:
-          $ref: '#/components/schemas/CompletionMessage'
-        started_at:
-          format: date-time
-          type: string
-        step_id:
-          type: string
-        step_type:
-          const: inference
-          default: inference
-          type: string
-        turn_id:
-          type: string
-      required:
-      - turn_id
-      - step_id
-      - step_type
-      - model_response
-      type: object
-    InsertChunksRequest:
-      additionalProperties: false
-      properties:
-        chunks:
-          items:
-            additionalProperties: false
-            properties:
-              content:
-                $ref: '#/components/schemas/InterleavedContent'
-              metadata:
-                additionalProperties:
-                  oneOf:
+            args:
+              type: object
+              additionalProperties:
+                oneOf:
                   - type: boolean
                   - type: number
                   - type: string
                   - type: array
                   - type: object
-                type: object
-            required:
-            - content
-            - metadata
-            type: object
-          type: array
-        ttl_seconds:
-          type: integer
-        vector_db_id:
-          type: string
-      required:
-      - vector_db_id
-      - chunks
+          additionalProperties: false
+          required:
+            - name
+            - args
+    AggregationFunctionType:
+      type: string
+      enum:
+        - average
+        - median
+        - categorical_count
+        - accuracy
+    BasicScoringFnParams:
       type: object
-    InsertRequest:
-      additionalProperties: false
       properties:
-        chunk_size_in_tokens:
-          type: integer
-        documents:
-          items:
-            $ref: '#/components/schemas/RAGDocument'
-          type: array
-        vector_db_id:
+        type:
           type: string
+          const: basic
+          default: basic
+        aggregation_functions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AggregationFunctionType'
+      additionalProperties: false
       required:
-      - documents
-      - vector_db_id
-      - chunk_size_in_tokens
+        - type
+    BenchmarkConfig:
       type: object
+      properties:
+        type:
+          type: string
+          const: benchmark
+          default: benchmark
+        eval_candidate:
+          $ref: '#/components/schemas/EvalCandidate'
+        scoring_params:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ScoringFnParams'
+        num_examples:
+          type: integer
+      additionalProperties: false
+      required:
+        - type
+        - eval_candidate
+        - scoring_params
+    EvalCandidate:
+      oneOf:
+        - $ref: '#/components/schemas/ModelCandidate'
+        - $ref: '#/components/schemas/AgentCandidate'
+      discriminator:
+        propertyName: type
+        mapping:
+          model: '#/components/schemas/ModelCandidate'
+          agent: '#/components/schemas/AgentCandidate'
+    GrammarResponseFormat:
+      type: object
+      properties:
+        type:
+          type: string
+          const: grammar
+          default: grammar
+          description: >-
+            Must be "grammar" to identify this format type
+        bnf:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+          description: >-
+            The BNF grammar specification the response should conform to
+      additionalProperties: false
+      required:
+        - type
+        - bnf
+      description: >-
+        Configuration for grammar-guided response generation.
+    GreedySamplingStrategy:
+      type: object
+      properties:
+        type:
+          type: string
+          const: greedy
+          default: greedy
+      additionalProperties: false
+      required:
+        - type
+    ImageContentItem:
+      type: object
+      properties:
+        type:
+          type: string
+          const: image
+          default: image
+          description: >-
+            Discriminator type of the content item. Always "image"
+        image:
+          type: object
+          properties:
+            url:
+              $ref: '#/components/schemas/URL'
+              description: >-
+                A URL of the image or data URL in the format of data:image/{type};base64,{data}.
+                Note that URL could have length limits.
+            data:
+              type: string
+              contentEncoding: base64
+              description: base64 encoded image data as string
+          additionalProperties: false
+          description: >-
+            Image as a base64 encoded string or an URL
+      additionalProperties: false
+      required:
+        - type
+        - image
+      description: A image content item
     InterleavedContent:
       oneOf:
-      - type: string
-      - $ref: '#/components/schemas/InterleavedContentItem'
-      - items:
-          $ref: '#/components/schemas/InterleavedContentItem'
-        type: array
+        - type: string
+        - $ref: '#/components/schemas/InterleavedContentItem'
+        - type: array
+          items:
+            $ref: '#/components/schemas/InterleavedContentItem'
     InterleavedContentItem:
+      oneOf:
+        - $ref: '#/components/schemas/ImageContentItem'
+        - $ref: '#/components/schemas/TextContentItem'
       discriminator:
+        propertyName: type
         mapping:
           image: '#/components/schemas/ImageContentItem'
           text: '#/components/schemas/TextContentItem'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/ImageContentItem'
-      - $ref: '#/components/schemas/TextContentItem'
-    InvokeToolRequest:
-      additionalProperties: false
-      properties:
-        kwargs:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        tool_name:
-          type: string
-      required:
-      - tool_name
-      - kwargs
-      type: object
-    Job:
-      additionalProperties: false
-      properties:
-        job_id:
-          type: string
-      required:
-      - job_id
-      type: object
-    JobStatus:
-      enum:
-      - completed
-      - in_progress
-      - failed
-      - scheduled
-      type: string
     JsonSchemaResponseFormat:
-      additionalProperties: false
+      type: object
       properties:
-        json_schema:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
         type:
+          type: string
           const: json_schema
           default: json_schema
-          type: string
-      required:
-      - type
-      - json_schema
-      type: object
-    JsonType:
+          description: >-
+            Must be "json_schema" to identify this format type
+        json_schema:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+          description: >-
+            The JSON schema the response should conform to. In a Python SDK, this
+            is often a `pydantic` model.
       additionalProperties: false
-      properties:
-        type:
-          const: json
-          default: json
-          type: string
       required:
-      - type
-      type: object
+        - type
+        - json_schema
+      description: >-
+        Configuration for JSON schema-guided response generation.
     LLMAsJudgeScoringFnParams:
-      additionalProperties: false
+      type: object
       properties:
-        aggregation_functions:
-          items:
-            $ref: '#/components/schemas/AggregationFunctionType'
-          type: array
-        judge_model:
-          type: string
-        judge_score_regexes:
-          items:
-            type: string
-          type: array
-        prompt_template:
-          type: string
         type:
+          type: string
           const: llm_as_judge
           default: llm_as_judge
+        judge_model:
           type: string
-      required:
-      - type
-      - judge_model
-      type: object
-    LLMRAGQueryGeneratorConfig:
-      additionalProperties: false
-      properties:
-        model:
+        prompt_template:
           type: string
-        template:
-          type: string
-        type:
-          const: llm
-          default: llm
-          type: string
-      required:
-      - type
-      - model
-      - template
-      type: object
-    ListDatasetsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Dataset'
+        judge_score_regexes:
           type: array
-      required:
-      - data
-      type: object
-    ListEvalTasksResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/EvalTask'
-          type: array
-      required:
-      - data
-      type: object
-    ListModelsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Model'
-          type: array
-      required:
-      - data
-      type: object
-    ListPostTrainingJobsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            additionalProperties: false
-            properties:
-              job_uuid:
-                type: string
-            required:
-            - job_uuid
-            type: object
-          type: array
-      required:
-      - data
-      type: object
-    ListProvidersResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/ProviderInfo'
-          type: array
-      required:
-      - data
-      type: object
-    ListRoutesResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/RouteInfo'
-          type: array
-      required:
-      - data
-      type: object
-    ListScoringFunctionsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/ScoringFn'
-          type: array
-      required:
-      - data
-      type: object
-    ListShieldsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Shield'
-          type: array
-      required:
-      - data
-      type: object
-    ListToolGroupsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/ToolGroup'
-          type: array
-      required:
-      - data
-      type: object
-    ListToolsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Tool'
-          type: array
-      required:
-      - data
-      type: object
-    ListVectorDBsResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/VectorDB'
-          type: array
-      required:
-      - data
-      type: object
-    LogEventRequest:
-      additionalProperties: false
-      properties:
-        event:
-          discriminator:
-            mapping:
-              metric: '#/components/schemas/MetricEvent'
-              structured_log: '#/components/schemas/StructuredLogEvent'
-              unstructured_log: '#/components/schemas/UnstructuredLogEvent'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/UnstructuredLogEvent'
-          - $ref: '#/components/schemas/MetricEvent'
-          - $ref: '#/components/schemas/StructuredLogEvent'
-        ttl_seconds:
-          type: integer
-      required:
-      - event
-      - ttl_seconds
-      type: object
-    LogSeverity:
-      enum:
-      - verbose
-      - debug
-      - info
-      - warn
-      - error
-      - critical
-      type: string
-    LoraFinetuningConfig:
-      additionalProperties: false
-      properties:
-        alpha:
-          type: integer
-        apply_lora_to_mlp:
-          type: boolean
-        apply_lora_to_output:
-          type: boolean
-        lora_attn_modules:
           items:
             type: string
+        aggregation_functions:
           type: array
-        quantize_base:
-          default: false
-          type: boolean
-        rank:
-          type: integer
-        type:
-          const: LoRA
-          default: LoRA
-          type: string
-        use_dora:
-          default: false
-          type: boolean
-      required:
-      - type
-      - lora_attn_modules
-      - apply_lora_to_mlp
-      - apply_lora_to_output
-      - rank
-      - alpha
-      type: object
-    MemoryRetrievalStep:
+          items:
+            $ref: '#/components/schemas/AggregationFunctionType'
       additionalProperties: false
-      properties:
-        completed_at:
-          format: date-time
-          type: string
-        inserted_context:
-          $ref: '#/components/schemas/InterleavedContent'
-        started_at:
-          format: date-time
-          type: string
-        step_id:
-          type: string
-        step_type:
-          const: memory_retrieval
-          default: memory_retrieval
-          type: string
-        turn_id:
-          type: string
-        vector_db_ids:
-          type: string
       required:
-      - turn_id
-      - step_id
-      - step_type
-      - vector_db_ids
-      - inserted_context
+        - type
+        - judge_model
+    ModelCandidate:
       type: object
-    Message:
-      discriminator:
-        mapping:
-          assistant: '#/components/schemas/CompletionMessage'
-          system: '#/components/schemas/SystemMessage'
-          tool: '#/components/schemas/ToolResponseMessage'
-          user: '#/components/schemas/UserMessage'
-        propertyName: role
-      oneOf:
-      - $ref: '#/components/schemas/UserMessage'
-      - $ref: '#/components/schemas/SystemMessage'
-      - $ref: '#/components/schemas/ToolResponseMessage'
-      - $ref: '#/components/schemas/CompletionMessage'
-    MetricEvent:
-      additionalProperties: false
       properties:
-        attributes:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        metric:
-          type: string
-        span_id:
-          type: string
-        timestamp:
-          format: date-time
-          type: string
-        trace_id:
-          type: string
         type:
-          const: metric
-          default: metric
           type: string
-        unit:
-          type: string
-        value:
-          oneOf:
-          - type: integer
-          - type: number
-      required:
-      - trace_id
-      - span_id
-      - timestamp
-      - type
-      - metric
-      - value
-      - unit
-      type: object
-    Model:
-      additionalProperties: false
-      properties:
-        identifier:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        model_type:
-          $ref: '#/components/schemas/ModelType'
-          default: llm
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        type:
           const: model
           default: model
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - metadata
-      - model_type
-      type: object
-    ModelCandidate:
-      additionalProperties: false
-      properties:
         model:
           type: string
         sampling_params:
           $ref: '#/components/schemas/SamplingParams'
         system_message:
           $ref: '#/components/schemas/SystemMessage'
-        type:
-          const: model
-          default: model
-          type: string
-      required:
-      - type
-      - model
-      - sampling_params
-      type: object
-    ModelType:
-      enum:
-      - llm
-      - embedding
-      type: string
-    NumberType:
       additionalProperties: false
+      required:
+        - type
+        - model
+        - sampling_params
+    RegexParserScoringFnParams:
+      type: object
       properties:
         type:
-          const: number
-          default: number
           type: string
-      required:
-      - type
-      type: object
-    ObjectType:
-      additionalProperties: false
-      properties:
-        type:
-          const: object
-          default: object
-          type: string
-      required:
-      - type
-      type: object
-    OptimizerConfig:
-      additionalProperties: false
-      properties:
-        lr:
-          type: number
-        num_warmup_steps:
-          type: integer
-        optimizer_type:
-          $ref: '#/components/schemas/OptimizerType'
-        weight_decay:
-          type: number
-      required:
-      - optimizer_type
-      - lr
-      - weight_decay
-      - num_warmup_steps
-      type: object
-    OptimizerType:
-      enum:
-      - adam
-      - adamw
-      - sgd
-      type: string
-    PaginatedRowsResult:
-      additionalProperties: false
-      properties:
-        next_page_token:
-          type: string
-        rows:
+          const: regex_parser
+          default: regex_parser
+        parsing_regexes:
+          type: array
           items:
-            additionalProperties:
-              oneOf:
+            type: string
+        aggregation_functions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AggregationFunctionType'
+      additionalProperties: false
+      required:
+        - type
+    ResponseFormat:
+      oneOf:
+        - $ref: '#/components/schemas/JsonSchemaResponseFormat'
+        - $ref: '#/components/schemas/GrammarResponseFormat'
+      discriminator:
+        propertyName: type
+        mapping:
+          json_schema: '#/components/schemas/JsonSchemaResponseFormat'
+          grammar: '#/components/schemas/GrammarResponseFormat'
+    SamplingParams:
+      type: object
+      properties:
+        strategy:
+          $ref: '#/components/schemas/SamplingStrategy'
+        max_tokens:
+          type: integer
+          default: 0
+        repetition_penalty:
+          type: number
+          default: 1.0
+      additionalProperties: false
+      required:
+        - strategy
+    SamplingStrategy:
+      oneOf:
+        - $ref: '#/components/schemas/GreedySamplingStrategy'
+        - $ref: '#/components/schemas/TopPSamplingStrategy'
+        - $ref: '#/components/schemas/TopKSamplingStrategy'
+      discriminator:
+        propertyName: type
+        mapping:
+          greedy: '#/components/schemas/GreedySamplingStrategy'
+          top_p: '#/components/schemas/TopPSamplingStrategy'
+          top_k: '#/components/schemas/TopKSamplingStrategy'
+    ScoringFnParams:
+      oneOf:
+        - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
+        - $ref: '#/components/schemas/RegexParserScoringFnParams'
+        - $ref: '#/components/schemas/BasicScoringFnParams'
+      discriminator:
+        propertyName: type
+        mapping:
+          llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
+          regex_parser: '#/components/schemas/RegexParserScoringFnParams'
+          basic: '#/components/schemas/BasicScoringFnParams'
+    SystemMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          const: system
+          default: system
+          description: >-
+            Must be "system" to identify this as a system message
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+          description: >-
+            The content of the "system prompt". If multiple system messages are provided,
+            they are concatenated. The underlying Llama Stack code may also add other
+            system messages (for example, for formatting tool definitions).
+      additionalProperties: false
+      required:
+        - role
+        - content
+      description: >-
+        A system message providing instructions or context to the model.
+    TextContentItem:
+      type: object
+      properties:
+        type:
+          type: string
+          const: text
+          default: text
+          description: >-
+            Discriminator type of the content item. Always "text"
+        text:
+          type: string
+          description: Text content
+      additionalProperties: false
+      required:
+        - type
+        - text
+      description: A text content item
+    ToolConfig:
+      type: object
+      properties:
+        tool_choice:
+          type: string
+          enum:
+            - auto
+            - required
+          description: >-
+            (Optional) Whether tool use is required or automatic. Defaults to ToolChoice.auto.
+          default: auto
+        tool_prompt_format:
+          type: string
+          enum:
+            - json
+            - function_tag
+            - python_list
+          description: >-
+            (Optional) Instructs the model how to format tool calls. By default, Llama
+            Stack will attempt to use a format that is best adapted to the model.
+            - `ToolPromptFormat.json`: The tool calls are formatted as a JSON object.
+            - `ToolPromptFormat.function_tag`: The tool calls are enclosed in a <function=function_name>
+            tag. - `ToolPromptFormat.python_list`: The tool calls are output as Python
+            syntax -- a list of function calls.
+        system_message_behavior:
+          type: string
+          enum:
+            - append
+            - replace
+          description: >-
+            (Optional) Config for how to override the default system prompt. - `SystemMessageBehavior.append`:
+            Appends the provided system message to the default system prompt. - `SystemMessageBehavior.replace`:
+            Replaces the default system prompt with the provided system message. The
+            system message can include the string '{{function_definitions}}' to indicate
+            where the function definitions should be inserted.
+          default: append
+      additionalProperties: false
+      required:
+        - system_message_behavior
+      description: Configuration for tool use.
+    ToolDef:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolParameter'
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
               - type: boolean
               - type: number
               - type: string
               - type: array
               - type: object
-            type: object
-          type: array
-        total_count:
-          type: integer
-      required:
-      - rows
-      - total_count
-      type: object
-    ParamType:
-      discriminator:
-        mapping:
-          agent_turn_input: '#/components/schemas/AgentTurnInputType'
-          array: '#/components/schemas/ArrayType'
-          boolean: '#/components/schemas/BooleanType'
-          chat_completion_input: '#/components/schemas/ChatCompletionInputType'
-          completion_input: '#/components/schemas/CompletionInputType'
-          json: '#/components/schemas/JsonType'
-          number: '#/components/schemas/NumberType'
-          object: '#/components/schemas/ObjectType'
-          string: '#/components/schemas/StringType'
-          union: '#/components/schemas/UnionType'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/StringType'
-      - $ref: '#/components/schemas/NumberType'
-      - $ref: '#/components/schemas/BooleanType'
-      - $ref: '#/components/schemas/ArrayType'
-      - $ref: '#/components/schemas/ObjectType'
-      - $ref: '#/components/schemas/JsonType'
-      - $ref: '#/components/schemas/UnionType'
-      - $ref: '#/components/schemas/ChatCompletionInputType'
-      - $ref: '#/components/schemas/CompletionInputType'
-      - $ref: '#/components/schemas/AgentTurnInputType'
-    PostTrainingJob:
       additionalProperties: false
-      properties:
-        job_uuid:
-          type: string
       required:
-      - job_uuid
+        - name
+    ToolParameter:
       type: object
-    PostTrainingJobArtifactsResponse:
-      additionalProperties: false
       properties:
-        checkpoints:
-          items:
-            $ref: '#/components/schemas/Checkpoint'
-          type: array
-        job_uuid:
+        name:
           type: string
-      required:
-      - job_uuid
-      - checkpoints
-      title: Artifacts of a finetuning job.
-      type: object
-    PostTrainingJobStatusResponse:
-      additionalProperties: false
-      properties:
-        checkpoints:
-          items:
-            $ref: '#/components/schemas/Checkpoint'
-          type: array
-        completed_at:
-          format: date-time
+        parameter_type:
           type: string
-        job_uuid:
+        description:
           type: string
-        resources_allocated:
-          additionalProperties:
-            oneOf:
+        required:
+          type: boolean
+          default: true
+        default:
+          oneOf:
             - type: boolean
             - type: number
             - type: string
             - type: array
             - type: object
+      additionalProperties: false
+      required:
+        - name
+        - parameter_type
+        - description
+        - required
+    TopKSamplingStrategy:
+      type: object
+      properties:
+        type:
+          type: string
+          const: top_k
+          default: top_k
+        top_k:
+          type: integer
+      additionalProperties: false
+      required:
+        - type
+        - top_k
+    TopPSamplingStrategy:
+      type: object
+      properties:
+        type:
+          type: string
+          const: top_p
+          default: top_p
+        temperature:
+          type: number
+        top_p:
+          type: number
+          default: 0.95
+      additionalProperties: false
+      required:
+        - type
+    URL:
+      type: object
+      properties:
+        uri:
+          type: string
+      additionalProperties: false
+      required:
+        - uri
+    DeprecatedEvaluateRowsRequest:
+      type: object
+      properties:
+        input_rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        scoring_functions:
+          type: array
+          items:
+            type: string
+        task_config:
+          $ref: '#/components/schemas/BenchmarkConfig'
+      additionalProperties: false
+      required:
+        - input_rows
+        - scoring_functions
+        - task_config
+    EvaluateResponse:
+      type: object
+      properties:
+        generations:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        scores:
           type: object
-        scheduled_at:
+          additionalProperties:
+            $ref: '#/components/schemas/ScoringResult'
+      additionalProperties: false
+      required:
+        - generations
+        - scores
+    ScoringResult:
+      type: object
+      properties:
+        score_rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        aggregated_results:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - score_rows
+        - aggregated_results
+    Benchmark:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: benchmark
+          default: benchmark
+        dataset_id:
+          type: string
+        scoring_functions:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - dataset_id
+        - scoring_functions
+        - metadata
+    JobStatus:
+      type: string
+      enum:
+        - completed
+        - in_progress
+        - failed
+        - scheduled
+    ListBenchmarksResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Benchmark'
+      additionalProperties: false
+      required:
+        - data
+    DeprecatedRegisterEvalTaskRequest:
+      type: object
+      properties:
+        eval_task_id:
+          type: string
+        dataset_id:
+          type: string
+        scoring_functions:
+          type: array
+          items:
+            type: string
+        provider_benchmark_id:
+          type: string
+        provider_id:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - eval_task_id
+        - dataset_id
+        - scoring_functions
+    DeprecatedRunEvalRequest:
+      type: object
+      properties:
+        task_config:
+          $ref: '#/components/schemas/BenchmarkConfig'
+      additionalProperties: false
+      required:
+        - task_config
+    Job:
+      type: object
+      properties:
+        job_id:
+          type: string
+      additionalProperties: false
+      required:
+        - job_id
+    AppendRowsRequest:
+      type: object
+      properties:
+        dataset_id:
+          type: string
+        rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+      additionalProperties: false
+      required:
+        - dataset_id
+        - rows
+    CompletionMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          const: assistant
+          default: assistant
+          description: >-
+            Must be "assistant" to identify this as the model's response
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+          description: The content of the model's response
+        stop_reason:
+          type: string
+          enum:
+            - end_of_turn
+            - end_of_message
+            - out_of_tokens
+          description: >-
+            Reason why the model stopped generating. Options are: - `StopReason.end_of_turn`:
+            The model finished generating the entire response. - `StopReason.end_of_message`:
+            The model finished generating but generated a partial response -- usually,
+            a tool call. The user may call the tool and continue the conversation
+            with the tool's response. - `StopReason.out_of_tokens`: The model ran
+            out of token budget.
+        tool_calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolCall'
+          description: >-
+            List of tool calls. Each tool call is a ToolCall object.
+      additionalProperties: false
+      required:
+        - role
+        - content
+        - stop_reason
+      description: >-
+        A message containing the model's (assistant) response in a chat conversation.
+    Message:
+      oneOf:
+        - $ref: '#/components/schemas/UserMessage'
+        - $ref: '#/components/schemas/SystemMessage'
+        - $ref: '#/components/schemas/ToolResponseMessage'
+        - $ref: '#/components/schemas/CompletionMessage'
+      discriminator:
+        propertyName: role
+        mapping:
+          user: '#/components/schemas/UserMessage'
+          system: '#/components/schemas/SystemMessage'
+          tool: '#/components/schemas/ToolResponseMessage'
+          assistant: '#/components/schemas/CompletionMessage'
+    ToolCall:
+      type: object
+      properties:
+        call_id:
+          type: string
+        tool_name:
+          oneOf:
+            - type: string
+              enum:
+                - brave_search
+                - wolfram_alpha
+                - photogen
+                - code_interpreter
+            - type: string
+        arguments:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
+              - type: array
+                items:
+                  oneOf:
+                    - type: string
+                    - type: integer
+                    - type: number
+                    - type: boolean
+              - type: object
+                additionalProperties:
+                  oneOf:
+                    - type: string
+                    - type: integer
+                    - type: number
+                    - type: boolean
+      additionalProperties: false
+      required:
+        - call_id
+        - tool_name
+        - arguments
+    ToolDefinition:
+      type: object
+      properties:
+        tool_name:
+          oneOf:
+            - type: string
+              enum:
+                - brave_search
+                - wolfram_alpha
+                - photogen
+                - code_interpreter
+            - type: string
+        description:
+          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolParamDefinition'
+      additionalProperties: false
+      required:
+        - tool_name
+    ToolParamDefinition:
+      type: object
+      properties:
+        param_type:
+          type: string
+        description:
+          type: string
+        required:
+          type: boolean
+          default: true
+        default:
+          oneOf:
+            - type: boolean
+            - type: number
+            - type: string
+            - type: array
+            - type: object
+      additionalProperties: false
+      required:
+        - param_type
+    ToolResponseMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          const: tool
+          default: tool
+          description: >-
+            Must be "tool" to identify this as a tool response
+        call_id:
+          type: string
+          description: >-
+            Unique identifier for the tool call this response is for
+        tool_name:
+          oneOf:
+            - type: string
+              enum:
+                - brave_search
+                - wolfram_alpha
+                - photogen
+                - code_interpreter
+            - type: string
+          description: Name of the tool that was called
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+          description: The response content from the tool
+      additionalProperties: false
+      required:
+        - role
+        - call_id
+        - tool_name
+        - content
+      description: >-
+        A message representing the result of a tool invocation.
+    UserMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          const: user
+          default: user
+          description: >-
+            Must be "user" to identify this as a user message
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+          description: >-
+            The content of the message, which can include text and other media
+        context:
+          $ref: '#/components/schemas/InterleavedContent'
+          description: >-
+            (Optional) This field is used internally by Llama Stack to pass RAG context.
+            This field may be removed in the API in the future.
+      additionalProperties: false
+      required:
+        - role
+        - content
+      description: >-
+        A message from the user in a chat conversation.
+    BatchChatCompletionRequest:
+      type: object
+      properties:
+        model:
+          type: string
+        messages_batch:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: '#/components/schemas/Message'
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolDefinition'
+        tool_choice:
+          type: string
+          enum:
+            - auto
+            - required
+          description: >-
+            Whether tool use is required or automatic. This is a hint to the model
+            which may not be followed. It depends on the Instruction Following capabilities
+            of the model.
+        tool_prompt_format:
+          type: string
+          enum:
+            - json
+            - function_tag
+            - python_list
+          description: >-
+            Prompt format for calling custom / zero shot tools.
+        response_format:
+          $ref: '#/components/schemas/ResponseFormat'
+        logprobs:
+          type: object
+          properties:
+            top_k:
+              type: integer
+              default: 0
+              description: >-
+                How many tokens (for each position) to return log probabilities for.
+          additionalProperties: false
+      additionalProperties: false
+      required:
+        - model
+        - messages_batch
+    BatchChatCompletionResponse:
+      type: object
+      properties:
+        batch:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatCompletionResponse'
+      additionalProperties: false
+      required:
+        - batch
+    ChatCompletionResponse:
+      type: object
+      properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricEvent'
+        completion_message:
+          $ref: '#/components/schemas/CompletionMessage'
+          description: The complete response message
+        logprobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenLogProbs'
+          description: >-
+            Optional log probabilities for generated tokens
+      additionalProperties: false
+      required:
+        - completion_message
+      description: Response from a chat completion request.
+    MetricEvent:
+      type: object
+      properties:
+        trace_id:
+          type: string
+        span_id:
+          type: string
+        timestamp:
+          type: string
           format: date-time
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
+        type:
+          type: string
+          const: metric
+          default: metric
+        metric:
+          type: string
+        value:
+          oneOf:
+            - type: integer
+            - type: number
+        unit:
+          type: string
+      additionalProperties: false
+      required:
+        - trace_id
+        - span_id
+        - timestamp
+        - type
+        - metric
+        - value
+        - unit
+    TokenLogProbs:
+      type: object
+      properties:
+        logprobs_by_token:
+          type: object
+          additionalProperties:
+            type: number
+          description: >-
+            Dictionary mapping tokens to their log probabilities
+      additionalProperties: false
+      required:
+        - logprobs_by_token
+      description: Log probabilities for generated tokens.
+    BatchCompletionRequest:
+      type: object
+      properties:
+        model:
+          type: string
+        content_batch:
+          type: array
+          items:
+            $ref: '#/components/schemas/InterleavedContent'
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+        response_format:
+          $ref: '#/components/schemas/ResponseFormat'
+        logprobs:
+          type: object
+          properties:
+            top_k:
+              type: integer
+              default: 0
+              description: >-
+                How many tokens (for each position) to return log probabilities for.
+          additionalProperties: false
+      additionalProperties: false
+      required:
+        - model
+        - content_batch
+    BatchCompletionResponse:
+      type: object
+      properties:
+        batch:
+          type: array
+          items:
+            $ref: '#/components/schemas/CompletionResponse'
+      additionalProperties: false
+      required:
+        - batch
+    CompletionResponse:
+      type: object
+      properties:
+        content:
+          type: string
+          description: The generated completion text
+        stop_reason:
+          type: string
+          enum:
+            - end_of_turn
+            - end_of_message
+            - out_of_tokens
+          description: Reason why generation stopped
+        logprobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenLogProbs'
+          description: >-
+            Optional log probabilities for generated tokens
+      additionalProperties: false
+      required:
+        - content
+        - stop_reason
+      description: Response from a completion request.
+    CancelTrainingJobRequest:
+      type: object
+      properties:
+        job_uuid:
+          type: string
+      additionalProperties: false
+      required:
+        - job_uuid
+    ChatCompletionRequest:
+      type: object
+      properties:
+        model_id:
+          type: string
+          description: >-
+            The identifier of the model to use. The model must be registered with
+            Llama Stack and available via the /models endpoint.
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+          description: List of messages in the conversation
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+          description: >-
+            Parameters to control the sampling strategy
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolDefinition'
+          description: >-
+            (Optional) List of tool definitions available to the model
+        tool_choice:
+          type: string
+          enum:
+            - auto
+            - required
+          description: >-
+            (Optional) Whether tool use is required or automatic. Defaults to ToolChoice.auto.
+            .. deprecated:: Use tool_config instead.
+        tool_prompt_format:
+          type: string
+          enum:
+            - json
+            - function_tag
+            - python_list
+          description: >-
+            (Optional) Instructs the model how to format tool calls. By default, Llama
+            Stack will attempt to use a format that is best adapted to the model.
+            - `ToolPromptFormat.json`: The tool calls are formatted as a JSON object.
+            - `ToolPromptFormat.function_tag`: The tool calls are enclosed in a <function=function_name>
+            tag. - `ToolPromptFormat.python_list`: The tool calls are output as Python
+            syntax -- a list of function calls. .. deprecated:: Use tool_config instead.
+        response_format:
+          $ref: '#/components/schemas/ResponseFormat'
+          description: >-
+            (Optional) Grammar specification for guided (structured) decoding. There
+            are two options: - `ResponseFormat.json_schema`: The grammar is a JSON
+            schema. Most providers support this format. - `ResponseFormat.grammar`:
+            The grammar is a BNF grammar. This format is more flexible, but not all
+            providers support it.
+        stream:
+          type: boolean
+          description: >-
+            (Optional) If True, generate an SSE event stream of the response. Defaults
+            to False.
+        logprobs:
+          type: object
+          properties:
+            top_k:
+              type: integer
+              default: 0
+              description: >-
+                How many tokens (for each position) to return log probabilities for.
+          additionalProperties: false
+          description: >-
+            (Optional) If specified, log probabilities for each token position will
+            be returned.
+        tool_config:
+          $ref: '#/components/schemas/ToolConfig'
+          description: (Optional) Configuration for tool use.
+      additionalProperties: false
+      required:
+        - model_id
+        - messages
+    ChatCompletionResponseEvent:
+      type: object
+      properties:
+        event_type:
+          type: string
+          enum:
+            - start
+            - complete
+            - progress
+          description: Type of the event
+        delta:
+          $ref: '#/components/schemas/ContentDelta'
+          description: >-
+            Content generated since last event. This can be one or more tokens, or
+            a tool call.
+        logprobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenLogProbs'
+          description: >-
+            Optional log probabilities for generated tokens
+        stop_reason:
+          type: string
+          enum:
+            - end_of_turn
+            - end_of_message
+            - out_of_tokens
+          description: >-
+            Optional reason why generation stopped, if complete
+      additionalProperties: false
+      required:
+        - event_type
+        - delta
+      description: >-
+        An event during chat completion generation.
+    ChatCompletionResponseStreamChunk:
+      type: object
+      properties:
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricEvent'
+        event:
+          $ref: '#/components/schemas/ChatCompletionResponseEvent'
+          description: The event containing the new content
+      additionalProperties: false
+      required:
+        - event
+      description: >-
+        A chunk of a streamed chat completion response.
+    ContentDelta:
+      oneOf:
+        - $ref: '#/components/schemas/TextDelta'
+        - $ref: '#/components/schemas/ImageDelta'
+        - $ref: '#/components/schemas/ToolCallDelta'
+      discriminator:
+        propertyName: type
+        mapping:
+          text: '#/components/schemas/TextDelta'
+          image: '#/components/schemas/ImageDelta'
+          tool_call: '#/components/schemas/ToolCallDelta'
+    ImageDelta:
+      type: object
+      properties:
+        type:
+          type: string
+          const: image
+          default: image
+        image:
+          type: string
+          contentEncoding: base64
+      additionalProperties: false
+      required:
+        - type
+        - image
+    TextDelta:
+      type: object
+      properties:
+        type:
+          type: string
+          const: text
+          default: text
+        text:
+          type: string
+      additionalProperties: false
+      required:
+        - type
+        - text
+    ToolCallDelta:
+      type: object
+      properties:
+        type:
+          type: string
+          const: tool_call
+          default: tool_call
+        tool_call:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/ToolCall'
+        parse_status:
+          type: string
+          enum:
+            - started
+            - in_progress
+            - failed
+            - succeeded
+      additionalProperties: false
+      required:
+        - type
+        - tool_call
+        - parse_status
+    CompletionRequest:
+      type: object
+      properties:
+        model_id:
+          type: string
+          description: >-
+            The identifier of the model to use. The model must be registered with
+            Llama Stack and available via the /models endpoint.
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+          description: The content to generate a completion for
+        sampling_params:
+          $ref: '#/components/schemas/SamplingParams'
+          description: >-
+            (Optional) Parameters to control the sampling strategy
+        response_format:
+          $ref: '#/components/schemas/ResponseFormat'
+          description: >-
+            (Optional) Grammar specification for guided (structured) decoding
+        stream:
+          type: boolean
+          description: >-
+            (Optional) If True, generate an SSE event stream of the response. Defaults
+            to False.
+        logprobs:
+          type: object
+          properties:
+            top_k:
+              type: integer
+              default: 0
+              description: >-
+                How many tokens (for each position) to return log probabilities for.
+          additionalProperties: false
+          description: >-
+            (Optional) If specified, log probabilities for each token position will
+            be returned.
+      additionalProperties: false
+      required:
+        - model_id
+        - content
+    CompletionResponseStreamChunk:
+      type: object
+      properties:
+        delta:
+          type: string
+          description: >-
+            New content generated since last chunk. This can be one or more tokens.
+        stop_reason:
+          type: string
+          enum:
+            - end_of_turn
+            - end_of_message
+            - out_of_tokens
+          description: >-
+            Optional reason why generation stopped, if complete
+        logprobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenLogProbs'
+          description: >-
+            Optional log probabilities for generated tokens
+      additionalProperties: false
+      required:
+        - delta
+      description: >-
+        A chunk of a streamed completion response.
+    CreateAgentRequest:
+      type: object
+      properties:
+        agent_config:
+          $ref: '#/components/schemas/AgentConfig'
+      additionalProperties: false
+      required:
+        - agent_config
+    AgentCreateResponse:
+      type: object
+      properties:
+        agent_id:
+          type: string
+      additionalProperties: false
+      required:
+        - agent_id
+    CreateAgentSessionRequest:
+      type: object
+      properties:
+        session_name:
+          type: string
+      additionalProperties: false
+      required:
+        - session_name
+    AgentSessionCreateResponse:
+      type: object
+      properties:
+        session_id:
+          type: string
+      additionalProperties: false
+      required:
+        - session_id
+    CreateAgentTurnRequest:
+      type: object
+      properties:
+        messages:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/UserMessage'
+              - $ref: '#/components/schemas/ToolResponseMessage'
+        stream:
+          type: boolean
+        documents:
+          type: array
+          items:
+            type: object
+            properties:
+              content:
+                oneOf:
+                  - type: string
+                  - $ref: '#/components/schemas/InterleavedContentItem'
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/InterleavedContentItem'
+                  - $ref: '#/components/schemas/URL'
+              mime_type:
+                type: string
+            additionalProperties: false
+            required:
+              - content
+              - mime_type
+        toolgroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentTool'
+        tool_config:
+          $ref: '#/components/schemas/ToolConfig'
+      additionalProperties: false
+      required:
+        - messages
+    InferenceStep:
+      type: object
+      properties:
+        turn_id:
+          type: string
+        step_id:
           type: string
         started_at:
+          type: string
           format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        step_type:
+          type: string
+          const: inference
+          default: inference
+        model_response:
+          $ref: '#/components/schemas/CompletionMessage'
+      additionalProperties: false
+      required:
+        - turn_id
+        - step_id
+        - step_type
+        - model_response
+    MemoryRetrievalStep:
+      type: object
+      properties:
+        turn_id:
+          type: string
+        step_id:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        step_type:
+          type: string
+          const: memory_retrieval
+          default: memory_retrieval
+        vector_db_ids:
+          type: string
+        inserted_context:
+          $ref: '#/components/schemas/InterleavedContent'
+      additionalProperties: false
+      required:
+        - turn_id
+        - step_id
+        - step_type
+        - vector_db_ids
+        - inserted_context
+    SafetyViolation:
+      type: object
+      properties:
+        violation_level:
+          $ref: '#/components/schemas/ViolationLevel'
+        user_message:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - violation_level
+        - metadata
+    ShieldCallStep:
+      type: object
+      properties:
+        turn_id:
+          type: string
+        step_id:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        step_type:
+          type: string
+          const: shield_call
+          default: shield_call
+        violation:
+          $ref: '#/components/schemas/SafetyViolation'
+      additionalProperties: false
+      required:
+        - turn_id
+        - step_id
+        - step_type
+    ToolExecutionStep:
+      type: object
+      properties:
+        turn_id:
+          type: string
+        step_id:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        step_type:
+          type: string
+          const: tool_execution
+          default: tool_execution
+        tool_calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolCall'
+        tool_responses:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolResponse'
+      additionalProperties: false
+      required:
+        - turn_id
+        - step_id
+        - step_type
+        - tool_calls
+        - tool_responses
+    ToolResponse:
+      type: object
+      properties:
+        call_id:
+          type: string
+        tool_name:
+          oneOf:
+            - type: string
+              enum:
+                - brave_search
+                - wolfram_alpha
+                - photogen
+                - code_interpreter
+            - type: string
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+      additionalProperties: false
+      required:
+        - call_id
+        - tool_name
+        - content
+    Turn:
+      type: object
+      properties:
+        turn_id:
+          type: string
+        session_id:
+          type: string
+        input_messages:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/UserMessage'
+              - $ref: '#/components/schemas/ToolResponseMessage'
+        steps:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/InferenceStep'
+              - $ref: '#/components/schemas/ToolExecutionStep'
+              - $ref: '#/components/schemas/ShieldCallStep'
+              - $ref: '#/components/schemas/MemoryRetrievalStep'
+            discriminator:
+              propertyName: step_type
+              mapping:
+                inference: '#/components/schemas/InferenceStep'
+                tool_execution: '#/components/schemas/ToolExecutionStep'
+                shield_call: '#/components/schemas/ShieldCallStep'
+                memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
+        output_message:
+          $ref: '#/components/schemas/CompletionMessage'
+        output_attachments:
+          type: array
+          items:
+            type: object
+            properties:
+              content:
+                oneOf:
+                  - type: string
+                  - $ref: '#/components/schemas/InterleavedContentItem'
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/InterleavedContentItem'
+                  - $ref: '#/components/schemas/URL'
+              mime_type:
+                type: string
+            additionalProperties: false
+            required:
+              - content
+              - mime_type
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+        - turn_id
+        - session_id
+        - input_messages
+        - steps
+        - output_message
+        - started_at
+      description: >-
+        A single turn in an interaction with an Agentic System.
+    ViolationLevel:
+      type: string
+      enum:
+        - info
+        - warn
+        - error
+    AgentTurnResponseEvent:
+      type: object
+      properties:
+        payload:
+          $ref: '#/components/schemas/AgentTurnResponseEventPayload'
+      additionalProperties: false
+      required:
+        - payload
+    AgentTurnResponseEventPayload:
+      oneOf:
+        - $ref: '#/components/schemas/AgentTurnResponseStepStartPayload'
+        - $ref: '#/components/schemas/AgentTurnResponseStepProgressPayload'
+        - $ref: '#/components/schemas/AgentTurnResponseStepCompletePayload'
+        - $ref: '#/components/schemas/AgentTurnResponseTurnStartPayload'
+        - $ref: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
+      discriminator:
+        propertyName: event_type
+        mapping:
+          step_start: '#/components/schemas/AgentTurnResponseStepStartPayload'
+          step_progress: '#/components/schemas/AgentTurnResponseStepProgressPayload'
+          step_complete: '#/components/schemas/AgentTurnResponseStepCompletePayload'
+          turn_start: '#/components/schemas/AgentTurnResponseTurnStartPayload'
+          turn_complete: '#/components/schemas/AgentTurnResponseTurnCompletePayload'
+    AgentTurnResponseStepCompletePayload:
+      type: object
+      properties:
+        event_type:
+          type: string
+          const: step_complete
+          default: step_complete
+        step_type:
+          type: string
+          enum:
+            - inference
+            - tool_execution
+            - shield_call
+            - memory_retrieval
+        step_id:
+          type: string
+        step_details:
+          oneOf:
+            - $ref: '#/components/schemas/InferenceStep'
+            - $ref: '#/components/schemas/ToolExecutionStep'
+            - $ref: '#/components/schemas/ShieldCallStep'
+            - $ref: '#/components/schemas/MemoryRetrievalStep'
+          discriminator:
+            propertyName: step_type
+            mapping:
+              inference: '#/components/schemas/InferenceStep'
+              tool_execution: '#/components/schemas/ToolExecutionStep'
+              shield_call: '#/components/schemas/ShieldCallStep'
+              memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
+      additionalProperties: false
+      required:
+        - event_type
+        - step_type
+        - step_id
+        - step_details
+    AgentTurnResponseStepProgressPayload:
+      type: object
+      properties:
+        event_type:
+          type: string
+          const: step_progress
+          default: step_progress
+        step_type:
+          type: string
+          enum:
+            - inference
+            - tool_execution
+            - shield_call
+            - memory_retrieval
+        step_id:
+          type: string
+        delta:
+          $ref: '#/components/schemas/ContentDelta'
+      additionalProperties: false
+      required:
+        - event_type
+        - step_type
+        - step_id
+        - delta
+    AgentTurnResponseStepStartPayload:
+      type: object
+      properties:
+        event_type:
+          type: string
+          const: step_start
+          default: step_start
+        step_type:
+          type: string
+          enum:
+            - inference
+            - tool_execution
+            - shield_call
+            - memory_retrieval
+        step_id:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - event_type
+        - step_type
+        - step_id
+    AgentTurnResponseStreamChunk:
+      type: object
+      properties:
+        event:
+          $ref: '#/components/schemas/AgentTurnResponseEvent'
+      additionalProperties: false
+      required:
+        - event
+      description: streamed agent turn completion response.
+    AgentTurnResponseTurnCompletePayload:
+      type: object
+      properties:
+        event_type:
+          type: string
+          const: turn_complete
+          default: turn_complete
+        turn:
+          $ref: '#/components/schemas/Turn'
+      additionalProperties: false
+      required:
+        - event_type
+        - turn
+    AgentTurnResponseTurnStartPayload:
+      type: object
+      properties:
+        event_type:
+          type: string
+          const: turn_start
+          default: turn_start
+        turn_id:
+          type: string
+      additionalProperties: false
+      required:
+        - event_type
+        - turn_id
+    EmbeddingsRequest:
+      type: object
+      properties:
+        model_id:
+          type: string
+          description: >-
+            The identifier of the model to use. The model must be an embedding model
+            registered with Llama Stack and available via the /models endpoint.
+        contents:
+          type: array
+          items:
+            $ref: '#/components/schemas/InterleavedContent'
+          description: >-
+            List of contents to generate embeddings for. Note that content can be
+            multimodal. The behavior depends on the model and provider. Some models
+            may only support text.
+      additionalProperties: false
+      required:
+        - model_id
+        - contents
+    EmbeddingsResponse:
+      type: object
+      properties:
+        embeddings:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+          description: >-
+            List of embedding vectors, one per input content. Each embedding is a
+            list of floats. The dimensionality of the embedding is model-specific;
+            you can check model metadata using /models/{model_id}
+      additionalProperties: false
+      required:
+        - embeddings
+      description: >-
+        Response containing generated embeddings.
+    EvaluateRowsRequest:
+      type: object
+      properties:
+        input_rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        scoring_functions:
+          type: array
+          items:
+            type: string
+        task_config:
+          $ref: '#/components/schemas/BenchmarkConfig'
+      additionalProperties: false
+      required:
+        - input_rows
+        - scoring_functions
+        - task_config
+    Session:
+      type: object
+      properties:
+        session_id:
+          type: string
+        session_name:
+          type: string
+        turns:
+          type: array
+          items:
+            $ref: '#/components/schemas/Turn'
+        started_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+        - session_id
+        - session_name
+        - turns
+        - started_at
+      description: >-
+        A single session of an interaction with an Agentic System.
+    AgentStepResponse:
+      type: object
+      properties:
+        step:
+          oneOf:
+            - $ref: '#/components/schemas/InferenceStep'
+            - $ref: '#/components/schemas/ToolExecutionStep'
+            - $ref: '#/components/schemas/ShieldCallStep'
+            - $ref: '#/components/schemas/MemoryRetrievalStep'
+          discriminator:
+            propertyName: step_type
+            mapping:
+              inference: '#/components/schemas/InferenceStep'
+              tool_execution: '#/components/schemas/ToolExecutionStep'
+              shield_call: '#/components/schemas/ShieldCallStep'
+              memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
+      additionalProperties: false
+      required:
+        - step
+    AgentTurnInputType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: agent_turn_input
+          default: agent_turn_input
+      additionalProperties: false
+      required:
+        - type
+    ArrayType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: array
+          default: array
+      additionalProperties: false
+      required:
+        - type
+    BooleanType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: boolean
+          default: boolean
+      additionalProperties: false
+      required:
+        - type
+    ChatCompletionInputType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: chat_completion_input
+          default: chat_completion_input
+      additionalProperties: false
+      required:
+        - type
+    CompletionInputType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: completion_input
+          default: completion_input
+      additionalProperties: false
+      required:
+        - type
+    Dataset:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: dataset
+          default: dataset
+        dataset_schema:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ParamType'
+        url:
+          $ref: '#/components/schemas/URL'
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - dataset_schema
+        - url
+        - metadata
+    JsonType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: json
+          default: json
+      additionalProperties: false
+      required:
+        - type
+    NumberType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: number
+          default: number
+      additionalProperties: false
+      required:
+        - type
+    ObjectType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: object
+          default: object
+      additionalProperties: false
+      required:
+        - type
+    ParamType:
+      oneOf:
+        - $ref: '#/components/schemas/StringType'
+        - $ref: '#/components/schemas/NumberType'
+        - $ref: '#/components/schemas/BooleanType'
+        - $ref: '#/components/schemas/ArrayType'
+        - $ref: '#/components/schemas/ObjectType'
+        - $ref: '#/components/schemas/JsonType'
+        - $ref: '#/components/schemas/UnionType'
+        - $ref: '#/components/schemas/ChatCompletionInputType'
+        - $ref: '#/components/schemas/CompletionInputType'
+        - $ref: '#/components/schemas/AgentTurnInputType'
+      discriminator:
+        propertyName: type
+        mapping:
+          string: '#/components/schemas/StringType'
+          number: '#/components/schemas/NumberType'
+          boolean: '#/components/schemas/BooleanType'
+          array: '#/components/schemas/ArrayType'
+          object: '#/components/schemas/ObjectType'
+          json: '#/components/schemas/JsonType'
+          union: '#/components/schemas/UnionType'
+          chat_completion_input: '#/components/schemas/ChatCompletionInputType'
+          completion_input: '#/components/schemas/CompletionInputType'
+          agent_turn_input: '#/components/schemas/AgentTurnInputType'
+    StringType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: string
+          default: string
+      additionalProperties: false
+      required:
+        - type
+    UnionType:
+      type: object
+      properties:
+        type:
+          type: string
+          const: union
+          default: union
+      additionalProperties: false
+      required:
+        - type
+    Model:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: model
+          default: model
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        model_type:
+          $ref: '#/components/schemas/ModelType'
+          default: llm
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - metadata
+        - model_type
+    ModelType:
+      type: string
+      enum:
+        - llm
+        - embedding
+    PaginatedRowsResult:
+      type: object
+      properties:
+        rows:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
+        total_count:
+          type: integer
+        next_page_token:
+          type: string
+      additionalProperties: false
+      required:
+        - rows
+        - total_count
+    ScoringFn:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: scoring_function
+          default: scoring_function
+        description:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        return_type:
+          $ref: '#/components/schemas/ParamType'
+        params:
+          $ref: '#/components/schemas/ScoringFnParams'
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - metadata
+        - return_type
+    Shield:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: shield
+          default: shield
+        params:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+      description: >-
+        A safety shield resource that can be used to check content
+    Span:
+      type: object
+      properties:
+        span_id:
+          type: string
+        trace_id:
+          type: string
+        parent_span_id:
+          type: string
+        name:
+          type: string
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - span_id
+        - trace_id
+        - name
+        - start_time
+    SpanStatus:
+      type: string
+      enum:
+        - ok
+        - error
+    SpanWithStatus:
+      type: object
+      properties:
+        span_id:
+          type: string
+        trace_id:
+          type: string
+        parent_span_id:
+          type: string
+        name:
+          type: string
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        attributes:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        status:
+          $ref: '#/components/schemas/SpanStatus'
+      additionalProperties: false
+      required:
+        - span_id
+        - trace_id
+        - name
+        - start_time
+    QuerySpanTreeResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/SpanWithStatus'
+      additionalProperties: false
+      required:
+        - data
+    Tool:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: tool
+          default: tool
+        toolgroup_id:
+          type: string
+        tool_host:
+          $ref: '#/components/schemas/ToolHost'
+        description:
+          type: string
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolParameter'
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - toolgroup_id
+        - tool_host
+        - description
+        - parameters
+    ToolHost:
+      type: string
+      enum:
+        - distribution
+        - client
+        - model_context_protocol
+    ToolGroup:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: tool_group
+          default: tool_group
+        mcp_endpoint:
+          $ref: '#/components/schemas/URL'
+        args:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+    Trace:
+      type: object
+      properties:
+        trace_id:
+          type: string
+        root_span_id:
+          type: string
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+        - trace_id
+        - root_span_id
+        - start_time
+    Checkpoint:
+      description: Checkpoint created during training runs
+    PostTrainingJobArtifactsResponse:
+      type: object
+      properties:
+        job_uuid:
+          type: string
+        checkpoints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Checkpoint'
+      additionalProperties: false
+      required:
+        - job_uuid
+        - checkpoints
+      description: Artifacts of a finetuning job.
+    PostTrainingJobStatusResponse:
+      type: object
+      properties:
+        job_uuid:
           type: string
         status:
           $ref: '#/components/schemas/JobStatus'
-      required:
-      - job_uuid
-      - status
-      - checkpoints
-      title: Status of a finetuning job.
-      type: object
-    PreferenceOptimizeRequest:
+        scheduled_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        resources_allocated:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        checkpoints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Checkpoint'
       additionalProperties: false
+      required:
+        - job_uuid
+        - status
+        - checkpoints
+      description: Status of a finetuning job.
+    ListPostTrainingJobsResponse:
+      type: object
       properties:
-        algorithm_config:
-          $ref: '#/components/schemas/DPOAlignmentConfig'
-        finetuned_model:
-          type: string
-        hyperparam_search_config:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        job_uuid:
-          type: string
-        logger_config:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        training_config:
-          $ref: '#/components/schemas/TrainingConfig'
-      required:
-      - job_uuid
-      - finetuned_model
-      - algorithm_config
-      - training_config
-      - hyperparam_search_config
-      - logger_config
-      type: object
-    ProviderInfo:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              job_uuid:
+                type: string
+            additionalProperties: false
+            required:
+              - job_uuid
       additionalProperties: false
+      required:
+        - data
+    VectorDB:
+      type: object
+      properties:
+        identifier:
+          type: string
+        provider_resource_id:
+          type: string
+        provider_id:
+          type: string
+        type:
+          type: string
+          const: vector_db
+          default: vector_db
+        embedding_model:
+          type: string
+        embedding_dimension:
+          type: integer
+      additionalProperties: false
+      required:
+        - identifier
+        - provider_resource_id
+        - provider_id
+        - type
+        - embedding_model
+        - embedding_dimension
+    HealthInfo:
+      type: object
+      properties:
+        status:
+          type: string
+      additionalProperties: false
+      required:
+        - status
+    RAGDocument:
+      type: object
+      properties:
+        document_id:
+          type: string
+        content:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/InterleavedContentItem'
+            - type: array
+              items:
+                $ref: '#/components/schemas/InterleavedContentItem'
+            - $ref: '#/components/schemas/URL'
+        mime_type:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - document_id
+        - content
+        - metadata
+    InsertRequest:
+      type: object
+      properties:
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/RAGDocument'
+        vector_db_id:
+          type: string
+        chunk_size_in_tokens:
+          type: integer
+      additionalProperties: false
+      required:
+        - documents
+        - vector_db_id
+        - chunk_size_in_tokens
+    InsertChunksRequest:
+      type: object
+      properties:
+        vector_db_id:
+          type: string
+        chunks:
+          type: array
+          items:
+            type: object
+            properties:
+              content:
+                $ref: '#/components/schemas/InterleavedContent'
+              metadata:
+                type: object
+                additionalProperties:
+                  oneOf:
+                    - type: boolean
+                    - type: number
+                    - type: string
+                    - type: array
+                    - type: object
+            additionalProperties: false
+            required:
+              - content
+              - metadata
+        ttl_seconds:
+          type: integer
+      additionalProperties: false
+      required:
+        - vector_db_id
+        - chunks
+    InvokeToolRequest:
+      type: object
+      properties:
+        tool_name:
+          type: string
+        kwargs:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - tool_name
+        - kwargs
+    ToolInvocationResult:
+      type: object
+      properties:
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+        error_message:
+          type: string
+        error_code:
+          type: integer
+      additionalProperties: false
+      required:
+        - content
+    ListDatasetsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Dataset'
+      additionalProperties: false
+      required:
+        - data
+    ListModelsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Model'
+      additionalProperties: false
+      required:
+        - data
+    ProviderInfo:
+      type: object
       properties:
         api:
           type: string
@@ -1716,80 +4179,518 @@ components:
           type: string
         provider_type:
           type: string
-      required:
-      - api
-      - provider_id
-      - provider_type
-      type: object
-    QATFinetuningConfig:
       additionalProperties: false
+      required:
+        - api
+        - provider_id
+        - provider_type
+    ListProvidersResponse:
+      type: object
       properties:
-        group_size:
-          type: integer
-        quantizer_name:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderInfo'
+      additionalProperties: false
+      required:
+        - data
+    RouteInfo:
+      type: object
+      properties:
+        route:
           type: string
+        method:
+          type: string
+        provider_types:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+      required:
+        - route
+        - method
+        - provider_types
+    ListRoutesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/RouteInfo'
+      additionalProperties: false
+      required:
+        - data
+    ListScoringFunctionsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScoringFn'
+      additionalProperties: false
+      required:
+        - data
+    ListShieldsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Shield'
+      additionalProperties: false
+      required:
+        - data
+    ListToolGroupsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolGroup'
+      additionalProperties: false
+      required:
+        - data
+    ListToolsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Tool'
+      additionalProperties: false
+      required:
+        - data
+    ListVectorDBsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/VectorDB'
+      additionalProperties: false
+      required:
+        - data
+    Event:
+      oneOf:
+        - $ref: '#/components/schemas/UnstructuredLogEvent'
+        - $ref: '#/components/schemas/MetricEvent'
+        - $ref: '#/components/schemas/StructuredLogEvent'
+      discriminator:
+        propertyName: type
+        mapping:
+          unstructured_log: '#/components/schemas/UnstructuredLogEvent'
+          metric: '#/components/schemas/MetricEvent'
+          structured_log: '#/components/schemas/StructuredLogEvent'
+    LogSeverity:
+      type: string
+      enum:
+        - verbose
+        - debug
+        - info
+        - warn
+        - error
+        - critical
+    SpanEndPayload:
+      type: object
+      properties:
         type:
-          const: QAT
-          default: QAT
           type: string
-      required:
-      - type
-      - quantizer_name
-      - group_size
-      type: object
-    QueryChunksRequest:
+          const: span_end
+          default: span_end
+        status:
+          $ref: '#/components/schemas/SpanStatus'
       additionalProperties: false
+      required:
+        - type
+        - status
+    SpanStartPayload:
+      type: object
       properties:
-        params:
+        type:
+          type: string
+          const: span_start
+          default: span_start
+        name:
+          type: string
+        parent_span_id:
+          type: string
+      additionalProperties: false
+      required:
+        - type
+        - name
+    StructuredLogEvent:
+      type: object
+      properties:
+        trace_id:
+          type: string
+        span_id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        attributes:
+          type: object
           additionalProperties:
             oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
+        type:
+          type: string
+          const: structured_log
+          default: structured_log
+        payload:
+          $ref: '#/components/schemas/StructuredLogPayload'
+      additionalProperties: false
+      required:
+        - trace_id
+        - span_id
+        - timestamp
+        - type
+        - payload
+    StructuredLogPayload:
+      oneOf:
+        - $ref: '#/components/schemas/SpanStartPayload'
+        - $ref: '#/components/schemas/SpanEndPayload'
+      discriminator:
+        propertyName: type
+        mapping:
+          span_start: '#/components/schemas/SpanStartPayload'
+          span_end: '#/components/schemas/SpanEndPayload'
+    UnstructuredLogEvent:
+      type: object
+      properties:
+        trace_id:
+          type: string
+        span_id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        attributes:
           type: object
-        query:
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
+        type:
+          type: string
+          const: unstructured_log
+          default: unstructured_log
+        message:
+          type: string
+        severity:
+          $ref: '#/components/schemas/LogSeverity'
+      additionalProperties: false
+      required:
+        - trace_id
+        - span_id
+        - timestamp
+        - type
+        - message
+        - severity
+    LogEventRequest:
+      type: object
+      properties:
+        event:
+          $ref: '#/components/schemas/Event'
+        ttl_seconds:
+          type: integer
+      additionalProperties: false
+      required:
+        - event
+        - ttl_seconds
+    DPOAlignmentConfig:
+      type: object
+      properties:
+        reward_scale:
+          type: number
+        reward_clip:
+          type: number
+        epsilon:
+          type: number
+        gamma:
+          type: number
+      additionalProperties: false
+      required:
+        - reward_scale
+        - reward_clip
+        - epsilon
+        - gamma
+    DataConfig:
+      type: object
+      properties:
+        dataset_id:
+          type: string
+        batch_size:
+          type: integer
+        shuffle:
+          type: boolean
+        data_format:
+          $ref: '#/components/schemas/DatasetFormat'
+        validation_dataset_id:
+          type: string
+        packed:
+          type: boolean
+          default: false
+        train_on_input:
+          type: boolean
+          default: false
+      additionalProperties: false
+      required:
+        - dataset_id
+        - batch_size
+        - shuffle
+        - data_format
+    DatasetFormat:
+      type: string
+      enum:
+        - instruct
+        - dialog
+    EfficiencyConfig:
+      type: object
+      properties:
+        enable_activation_checkpointing:
+          type: boolean
+          default: false
+        enable_activation_offloading:
+          type: boolean
+          default: false
+        memory_efficient_fsdp_wrap:
+          type: boolean
+          default: false
+        fsdp_cpu_offload:
+          type: boolean
+          default: false
+      additionalProperties: false
+    OptimizerConfig:
+      type: object
+      properties:
+        optimizer_type:
+          $ref: '#/components/schemas/OptimizerType'
+        lr:
+          type: number
+        weight_decay:
+          type: number
+        num_warmup_steps:
+          type: integer
+      additionalProperties: false
+      required:
+        - optimizer_type
+        - lr
+        - weight_decay
+        - num_warmup_steps
+    OptimizerType:
+      type: string
+      enum:
+        - adam
+        - adamw
+        - sgd
+    TrainingConfig:
+      type: object
+      properties:
+        n_epochs:
+          type: integer
+        max_steps_per_epoch:
+          type: integer
+        gradient_accumulation_steps:
+          type: integer
+        max_validation_steps:
+          type: integer
+        data_config:
+          $ref: '#/components/schemas/DataConfig'
+        optimizer_config:
+          $ref: '#/components/schemas/OptimizerConfig'
+        efficiency_config:
+          $ref: '#/components/schemas/EfficiencyConfig'
+        dtype:
+          type: string
+          default: bf16
+      additionalProperties: false
+      required:
+        - n_epochs
+        - max_steps_per_epoch
+        - gradient_accumulation_steps
+        - max_validation_steps
+        - data_config
+        - optimizer_config
+    PreferenceOptimizeRequest:
+      type: object
+      properties:
+        job_uuid:
+          type: string
+        finetuned_model:
+          type: string
+        algorithm_config:
+          $ref: '#/components/schemas/DPOAlignmentConfig'
+        training_config:
+          $ref: '#/components/schemas/TrainingConfig'
+        hyperparam_search_config:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        logger_config:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - job_uuid
+        - finetuned_model
+        - algorithm_config
+        - training_config
+        - hyperparam_search_config
+        - logger_config
+    PostTrainingJob:
+      type: object
+      properties:
+        job_uuid:
+          type: string
+      additionalProperties: false
+      required:
+        - job_uuid
+    DefaultRAGQueryGeneratorConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          const: default
+          default: default
+        separator:
+          type: string
+          default: ' '
+      additionalProperties: false
+      required:
+        - type
+        - separator
+    LLMRAGQueryGeneratorConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          const: llm
+          default: llm
+        model:
+          type: string
+        template:
+          type: string
+      additionalProperties: false
+      required:
+        - type
+        - model
+        - template
+    RAGQueryConfig:
+      type: object
+      properties:
+        query_generator_config:
+          $ref: '#/components/schemas/RAGQueryGeneratorConfig'
+        max_tokens_in_context:
+          type: integer
+          default: 4096
+        max_chunks:
+          type: integer
+          default: 5
+      additionalProperties: false
+      required:
+        - query_generator_config
+        - max_tokens_in_context
+        - max_chunks
+    RAGQueryGeneratorConfig:
+      oneOf:
+        - $ref: '#/components/schemas/DefaultRAGQueryGeneratorConfig'
+        - $ref: '#/components/schemas/LLMRAGQueryGeneratorConfig'
+      discriminator:
+        propertyName: type
+        mapping:
+          default: '#/components/schemas/DefaultRAGQueryGeneratorConfig'
+          llm: '#/components/schemas/LLMRAGQueryGeneratorConfig'
+    QueryRequest:
+      type: object
+      properties:
+        content:
           $ref: '#/components/schemas/InterleavedContent'
+        vector_db_ids:
+          type: array
+          items:
+            type: string
+        query_config:
+          $ref: '#/components/schemas/RAGQueryConfig'
+      additionalProperties: false
+      required:
+        - content
+        - vector_db_ids
+    RAGQueryResult:
+      type: object
+      properties:
+        content:
+          $ref: '#/components/schemas/InterleavedContent'
+      additionalProperties: false
+    QueryChunksRequest:
+      type: object
+      properties:
         vector_db_id:
           type: string
-      required:
-      - vector_db_id
-      - query
-      type: object
-    QueryChunksResponse:
+        query:
+          $ref: '#/components/schemas/InterleavedContent'
+        params:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
       additionalProperties: false
+      required:
+        - vector_db_id
+        - query
+    QueryChunksResponse:
+      type: object
       properties:
         chunks:
+          type: array
           items:
-            additionalProperties: false
+            type: object
             properties:
               content:
                 $ref: '#/components/schemas/InterleavedContent'
               metadata:
+                type: object
                 additionalProperties:
                   oneOf:
-                  - type: boolean
-                  - type: number
-                  - type: string
-                  - type: array
-                  - type: object
-                type: object
+                    - type: boolean
+                    - type: number
+                    - type: string
+                    - type: array
+                    - type: object
+            additionalProperties: false
             required:
-            - content
-            - metadata
-            type: object
-          type: array
+              - content
+              - metadata
         scores:
+          type: array
           items:
             type: number
-          type: array
-      required:
-      - chunks
-      - scores
-      type: object
-    QueryCondition:
       additionalProperties: false
+      required:
+        - chunks
+        - scores
+    QueryCondition:
+      type: object
       properties:
         key:
           type: string
@@ -1797,4663 +4698,549 @@ components:
           $ref: '#/components/schemas/QueryConditionOp'
         value:
           oneOf:
-          - type: boolean
-          - type: number
-          - type: string
-          - type: array
-          - type: object
-      required:
-      - key
-      - op
-      - value
-      type: object
-    QueryConditionOp:
-      enum:
-      - eq
-      - ne
-      - gt
-      - lt
-      type: string
-    QueryRequest:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        query_config:
-          $ref: '#/components/schemas/RAGQueryConfig'
-        vector_db_ids:
-          items:
-            type: string
-          type: array
-      required:
-      - content
-      - vector_db_ids
-      type: object
-    QuerySpanTreeResponse:
-      additionalProperties: false
-      properties:
-        data:
-          additionalProperties:
-            $ref: '#/components/schemas/SpanWithStatus'
-          type: object
-      required:
-      - data
-      type: object
-    QuerySpansResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Span'
-          type: array
-      required:
-      - data
-      type: object
-    QueryTracesResponse:
-      additionalProperties: false
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Trace'
-          type: array
-      required:
-      - data
-      type: object
-    RAGDocument:
-      additionalProperties: false
-      properties:
-        content:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/InterleavedContentItem'
-          - items:
-              $ref: '#/components/schemas/InterleavedContentItem'
-            type: array
-          - $ref: '#/components/schemas/URL'
-        document_id:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
             - type: boolean
             - type: number
             - type: string
             - type: array
             - type: object
-          type: object
-        mime_type:
-          type: string
+      additionalProperties: false
       required:
-      - document_id
-      - content
-      - metadata
+        - key
+        - op
+        - value
+    QueryConditionOp:
+      type: string
+      enum:
+        - eq
+        - ne
+        - gt
+        - lt
+    QuerySpansResponse:
       type: object
-    RAGQueryConfig:
-      additionalProperties: false
       properties:
-        max_chunks:
-          default: 5
-          type: integer
-        max_tokens_in_context:
-          default: 4096
-          type: integer
-        query_generator_config:
-          $ref: '#/components/schemas/RAGQueryGeneratorConfig'
-      required:
-      - query_generator_config
-      - max_tokens_in_context
-      - max_chunks
-      type: object
-    RAGQueryGeneratorConfig:
-      discriminator:
-        mapping:
-          default: '#/components/schemas/DefaultRAGQueryGeneratorConfig'
-          llm: '#/components/schemas/LLMRAGQueryGeneratorConfig'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/DefaultRAGQueryGeneratorConfig'
-      - $ref: '#/components/schemas/LLMRAGQueryGeneratorConfig'
-    RAGQueryResult:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-      type: object
-    RegexParserScoringFnParams:
-      additionalProperties: false
-      properties:
-        aggregation_functions:
-          items:
-            $ref: '#/components/schemas/AggregationFunctionType'
+        data:
           type: array
-        parsing_regexes:
+          items:
+            $ref: '#/components/schemas/Span'
+      additionalProperties: false
+      required:
+        - data
+    QueryTracesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Trace'
+      additionalProperties: false
+      required:
+        - data
+    RegisterBenchmarkRequest:
+      type: object
+      properties:
+        benchmark_id:
+          type: string
+        dataset_id:
+          type: string
+        scoring_functions:
+          type: array
           items:
             type: string
-          type: array
-        type:
-          const: regex_parser
-          default: regex_parser
+        provider_benchmark_id:
           type: string
-      required:
-      - type
-      type: object
-    RegisterDatasetRequest:
+        provider_id:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
       additionalProperties: false
+      required:
+        - benchmark_id
+        - dataset_id
+        - scoring_functions
+    RegisterDatasetRequest:
+      type: object
       properties:
         dataset_id:
           type: string
         dataset_schema:
+          type: object
           additionalProperties:
             $ref: '#/components/schemas/ParamType'
-          type: object
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
+        url:
+          $ref: '#/components/schemas/URL'
         provider_dataset_id:
           type: string
         provider_id:
           type: string
-        url:
-          $ref: '#/components/schemas/URL'
-      required:
-      - dataset_id
-      - dataset_schema
-      - url
-      type: object
-    RegisterEvalTaskRequest:
-      additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        eval_task_id:
-          type: string
         metadata:
+          type: object
           additionalProperties:
             oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        provider_eval_task_id:
-          type: string
-        provider_id:
-          type: string
-        scoring_functions:
-          items:
-            type: string
-          type: array
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
       required:
-      - eval_task_id
-      - dataset_id
-      - scoring_functions
-      type: object
+        - dataset_id
+        - dataset_schema
+        - url
     RegisterModelRequest:
-      additionalProperties: false
+      type: object
       properties:
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
         model_id:
-          type: string
-        model_type:
-          $ref: '#/components/schemas/ModelType'
-        provider_id:
           type: string
         provider_model_id:
           type: string
-      required:
-      - model_id
-      type: object
-    RegisterScoringFunctionRequest:
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        params:
-          discriminator:
-            mapping:
-              basic: '#/components/schemas/BasicScoringFnParams'
-              llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-              regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-          - $ref: '#/components/schemas/RegexParserScoringFnParams'
-          - $ref: '#/components/schemas/BasicScoringFnParams'
         provider_id:
           type: string
-        provider_scoring_fn_id:
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        model_type:
+          $ref: '#/components/schemas/ModelType'
+      additionalProperties: false
+      required:
+        - model_id
+    RegisterScoringFunctionRequest:
+      type: object
+      properties:
+        scoring_fn_id:
+          type: string
+        description:
           type: string
         return_type:
           $ref: '#/components/schemas/ParamType'
-        scoring_fn_id:
+        provider_scoring_fn_id:
           type: string
-      required:
-      - scoring_fn_id
-      - description
-      - return_type
-      type: object
-    RegisterShieldRequest:
-      additionalProperties: false
-      properties:
-        params:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
         provider_id:
+          type: string
+        params:
+          $ref: '#/components/schemas/ScoringFnParams'
+      additionalProperties: false
+      required:
+        - scoring_fn_id
+        - description
+        - return_type
+    RegisterShieldRequest:
+      type: object
+      properties:
+        shield_id:
           type: string
         provider_shield_id:
           type: string
-        shield_id:
-          type: string
-      required:
-      - shield_id
-      type: object
-    RegisterToolGroupRequest:
-      additionalProperties: false
-      properties:
-        args:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        mcp_endpoint:
-          $ref: '#/components/schemas/URL'
         provider_id:
           type: string
+        params:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+      additionalProperties: false
+      required:
+        - shield_id
+    RegisterToolGroupRequest:
+      type: object
+      properties:
         toolgroup_id:
           type: string
-      required:
-      - toolgroup_id
-      - provider_id
-      type: object
-    RegisterVectorDbRequest:
+        provider_id:
+          type: string
+        mcp_endpoint:
+          $ref: '#/components/schemas/URL'
+        args:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
       additionalProperties: false
+      required:
+        - toolgroup_id
+        - provider_id
+    RegisterVectorDbRequest:
+      type: object
       properties:
-        embedding_dimension:
-          type: integer
+        vector_db_id:
+          type: string
         embedding_model:
           type: string
+        embedding_dimension:
+          type: integer
         provider_id:
           type: string
         provider_vector_db_id:
           type: string
-        vector_db_id:
-          type: string
-      required:
-      - vector_db_id
-      - embedding_model
-      type: object
-    ResponseFormat:
-      discriminator:
-        mapping:
-          grammar: '#/components/schemas/GrammarResponseFormat'
-          json_schema: '#/components/schemas/JsonSchemaResponseFormat'
-        propertyName: type
-      oneOf:
-      - $ref: '#/components/schemas/JsonSchemaResponseFormat'
-      - $ref: '#/components/schemas/GrammarResponseFormat'
-    RouteInfo:
       additionalProperties: false
-      properties:
-        method:
-          type: string
-        provider_types:
-          items:
-            type: string
-          type: array
-        route:
-          type: string
       required:
-      - route
-      - method
-      - provider_types
-      type: object
+        - vector_db_id
+        - embedding_model
     RunEvalRequest:
-      additionalProperties: false
+      type: object
       properties:
         task_config:
-          discriminator:
-            mapping:
-              app: '#/components/schemas/AppEvalTaskConfig'
-              benchmark: '#/components/schemas/BenchmarkEvalTaskConfig'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/BenchmarkEvalTaskConfig'
-          - $ref: '#/components/schemas/AppEvalTaskConfig'
-      required:
-      - task_config
-      type: object
-    RunShieldRequest:
+          $ref: '#/components/schemas/BenchmarkConfig'
       additionalProperties: false
+      required:
+        - task_config
+    RunShieldRequest:
+      type: object
       properties:
-        messages:
-          items:
-            $ref: '#/components/schemas/Message'
-          type: array
-        params:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
         shield_id:
           type: string
-      required:
-      - shield_id
-      - messages
-      - params
-      type: object
-    RunShieldResponse:
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+        params:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
       additionalProperties: false
+      required:
+        - shield_id
+        - messages
+        - params
+    RunShieldResponse:
+      type: object
       properties:
         violation:
           $ref: '#/components/schemas/SafetyViolation'
-      type: object
-    SafetyViolation:
       additionalProperties: false
-      properties:
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        user_message:
-          type: string
-        violation_level:
-          $ref: '#/components/schemas/ViolationLevel'
-      required:
-      - violation_level
-      - metadata
-      type: object
-    SamplingParams:
-      additionalProperties: false
-      properties:
-        max_tokens:
-          default: 0
-          type: integer
-        repetition_penalty:
-          default: 1.0
-          type: number
-        strategy:
-          discriminator:
-            mapping:
-              greedy: '#/components/schemas/GreedySamplingStrategy'
-              top_k: '#/components/schemas/TopKSamplingStrategy'
-              top_p: '#/components/schemas/TopPSamplingStrategy'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/GreedySamplingStrategy'
-          - $ref: '#/components/schemas/TopPSamplingStrategy'
-          - $ref: '#/components/schemas/TopKSamplingStrategy'
-      required:
-      - strategy
-      type: object
     SaveSpansToDatasetRequest:
-      additionalProperties: false
+      type: object
       properties:
         attribute_filters:
+          type: array
           items:
             $ref: '#/components/schemas/QueryCondition'
-          type: array
         attributes_to_save:
+          type: array
           items:
             type: string
-          type: array
         dataset_id:
           type: string
         max_depth:
           type: integer
-      required:
-      - attribute_filters
-      - attributes_to_save
-      - dataset_id
-      type: object
-    ScoreBatchRequest:
       additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        save_results_dataset:
-          type: boolean
-        scoring_functions:
-          additionalProperties:
-            oneOf:
-            - discriminator:
-                mapping:
-                  basic: '#/components/schemas/BasicScoringFnParams'
-                  llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-                  regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-                propertyName: type
-              oneOf:
-              - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-              - $ref: '#/components/schemas/RegexParserScoringFnParams'
-              - $ref: '#/components/schemas/BasicScoringFnParams'
-          type: object
       required:
-      - dataset_id
-      - scoring_functions
-      - save_results_dataset
-      type: object
-    ScoreBatchResponse:
-      additionalProperties: false
-      properties:
-        dataset_id:
-          type: string
-        results:
-          additionalProperties:
-            $ref: '#/components/schemas/ScoringResult'
-          type: object
-      required:
-      - results
-      type: object
+        - attribute_filters
+        - attributes_to_save
+        - dataset_id
     ScoreRequest:
-      additionalProperties: false
+      type: object
       properties:
         input_rows:
+          type: array
           items:
+            type: object
             additionalProperties:
               oneOf:
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
-          type: array
+                - type: boolean
+                - type: number
+                - type: string
+                - type: array
+                - type: object
         scoring_functions:
+          type: object
           additionalProperties:
             oneOf:
-            - discriminator:
-                mapping:
-                  basic: '#/components/schemas/BasicScoringFnParams'
-                  llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-                  regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-                propertyName: type
-              oneOf:
-              - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-              - $ref: '#/components/schemas/RegexParserScoringFnParams'
-              - $ref: '#/components/schemas/BasicScoringFnParams'
-          type: object
-      required:
-      - input_rows
-      - scoring_functions
-      type: object
-    ScoreResponse:
+              - $ref: '#/components/schemas/ScoringFnParams'
       additionalProperties: false
+      required:
+        - input_rows
+        - scoring_functions
+    ScoreResponse:
+      type: object
       properties:
         results:
+          type: object
           additionalProperties:
             $ref: '#/components/schemas/ScoringResult'
-          type: object
-      required:
-      - results
-      type: object
-    ScoringFn:
       additionalProperties: false
+      required:
+        - results
+    ScoreBatchRequest:
+      type: object
       properties:
-        description:
+        dataset_id:
           type: string
-        identifier:
-          type: string
-        metadata:
+        scoring_functions:
+          type: object
           additionalProperties:
             oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
+              - $ref: '#/components/schemas/ScoringFnParams'
+        save_results_dataset:
+          type: boolean
+      additionalProperties: false
+      required:
+        - dataset_id
+        - scoring_functions
+        - save_results_dataset
+    ScoreBatchResponse:
+      type: object
+      properties:
+        dataset_id:
+          type: string
+        results:
           type: object
-        params:
-          discriminator:
-            mapping:
-              basic: '#/components/schemas/BasicScoringFnParams'
-              llm_as_judge: '#/components/schemas/LLMAsJudgeScoringFnParams'
-              regex_parser: '#/components/schemas/RegexParserScoringFnParams'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/LLMAsJudgeScoringFnParams'
-          - $ref: '#/components/schemas/RegexParserScoringFnParams'
-          - $ref: '#/components/schemas/BasicScoringFnParams'
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        return_type:
-          $ref: '#/components/schemas/ParamType'
+          additionalProperties:
+            $ref: '#/components/schemas/ScoringResult'
+      additionalProperties: false
+      required:
+        - results
+    AlgorithmConfig:
+      oneOf:
+        - $ref: '#/components/schemas/LoraFinetuningConfig'
+        - $ref: '#/components/schemas/QATFinetuningConfig'
+      discriminator:
+        propertyName: type
+        mapping:
+          LoRA: '#/components/schemas/LoraFinetuningConfig'
+          QAT: '#/components/schemas/QATFinetuningConfig'
+    LoraFinetuningConfig:
+      type: object
+      properties:
         type:
-          const: scoring_function
-          default: scoring_function
           type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - metadata
-      - return_type
-      type: object
-    ScoringResult:
-      additionalProperties: false
-      properties:
-        aggregated_results:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        score_rows:
-          items:
-            additionalProperties:
-              oneOf:
-              - type: boolean
-              - type: number
-              - type: string
-              - type: array
-              - type: object
-            type: object
+          const: LoRA
+          default: LoRA
+        lora_attn_modules:
           type: array
-      required:
-      - score_rows
-      - aggregated_results
-      type: object
-    Session:
-      additionalProperties: false
-      properties:
-        session_id:
-          type: string
-        session_name:
-          type: string
-        started_at:
-          format: date-time
-          type: string
-        turns:
           items:
-            $ref: '#/components/schemas/Turn'
-          type: array
-      required:
-      - session_id
-      - session_name
-      - turns
-      - started_at
-      title: A single session of an interaction with an Agentic System.
-      type: object
-    Shield:
+            type: string
+        apply_lora_to_mlp:
+          type: boolean
+        apply_lora_to_output:
+          type: boolean
+        rank:
+          type: integer
+        alpha:
+          type: integer
+        use_dora:
+          type: boolean
+          default: false
+        quantize_base:
+          type: boolean
+          default: false
       additionalProperties: false
-      properties:
-        identifier:
-          type: string
-        params:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        type:
-          const: shield
-          default: shield
-          type: string
       required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      title: A safety shield resource that can be used to check content
+        - type
+        - lora_attn_modules
+        - apply_lora_to_mlp
+        - apply_lora_to_output
+        - rank
+        - alpha
+    QATFinetuningConfig:
       type: object
-    ShieldCallStep:
-      additionalProperties: false
-      properties:
-        completed_at:
-          format: date-time
-          type: string
-        started_at:
-          format: date-time
-          type: string
-        step_id:
-          type: string
-        step_type:
-          const: shield_call
-          default: shield_call
-          type: string
-        turn_id:
-          type: string
-        violation:
-          $ref: '#/components/schemas/SafetyViolation'
-      required:
-      - turn_id
-      - step_id
-      - step_type
-      type: object
-    Span:
-      additionalProperties: false
-      properties:
-        attributes:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        end_time:
-          format: date-time
-          type: string
-        name:
-          type: string
-        parent_span_id:
-          type: string
-        span_id:
-          type: string
-        start_time:
-          format: date-time
-          type: string
-        trace_id:
-          type: string
-      required:
-      - span_id
-      - trace_id
-      - name
-      - start_time
-      type: object
-    SpanEndPayload:
-      additionalProperties: false
-      properties:
-        status:
-          $ref: '#/components/schemas/SpanStatus'
-        type:
-          const: span_end
-          default: span_end
-          type: string
-      required:
-      - type
-      - status
-      type: object
-    SpanStartPayload:
-      additionalProperties: false
-      properties:
-        name:
-          type: string
-        parent_span_id:
-          type: string
-        type:
-          const: span_start
-          default: span_start
-          type: string
-      required:
-      - type
-      - name
-      type: object
-    SpanStatus:
-      enum:
-      - ok
-      - error
-      type: string
-    SpanWithStatus:
-      additionalProperties: false
-      properties:
-        attributes:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        end_time:
-          format: date-time
-          type: string
-        name:
-          type: string
-        parent_span_id:
-          type: string
-        span_id:
-          type: string
-        start_time:
-          format: date-time
-          type: string
-        status:
-          $ref: '#/components/schemas/SpanStatus'
-        trace_id:
-          type: string
-      required:
-      - span_id
-      - trace_id
-      - name
-      - start_time
-      type: object
-    StopReason:
-      enum:
-      - end_of_turn
-      - end_of_message
-      - out_of_tokens
-      type: string
-    StringType:
-      additionalProperties: false
       properties:
         type:
-          const: string
-          default: string
           type: string
-      required:
-      - type
-      type: object
-    StructuredLogEvent:
+          const: QAT
+          default: QAT
+        quantizer_name:
+          type: string
+        group_size:
+          type: integer
       additionalProperties: false
-      properties:
-        attributes:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        payload:
-          discriminator:
-            mapping:
-              span_end: '#/components/schemas/SpanEndPayload'
-              span_start: '#/components/schemas/SpanStartPayload'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/SpanStartPayload'
-          - $ref: '#/components/schemas/SpanEndPayload'
-        span_id:
-          type: string
-        timestamp:
-          format: date-time
-          type: string
-        trace_id:
-          type: string
-        type:
-          const: structured_log
-          default: structured_log
-          type: string
       required:
-      - trace_id
-      - span_id
-      - timestamp
-      - type
-      - payload
-      type: object
+        - type
+        - quantizer_name
+        - group_size
     SupervisedFineTuneRequest:
-      additionalProperties: false
+      type: object
       properties:
-        algorithm_config:
-          discriminator:
-            mapping:
-              LoRA: '#/components/schemas/LoraFinetuningConfig'
-              QAT: '#/components/schemas/QATFinetuningConfig'
-            propertyName: type
-          oneOf:
-          - $ref: '#/components/schemas/LoraFinetuningConfig'
-          - $ref: '#/components/schemas/QATFinetuningConfig'
-        checkpoint_dir:
-          type: string
-        hyperparam_search_config:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
         job_uuid:
-          type: string
-        logger_config:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        model:
           type: string
         training_config:
           $ref: '#/components/schemas/TrainingConfig'
-      required:
-      - job_uuid
-      - training_config
-      - hyperparam_search_config
-      - logger_config
-      - model
-      type: object
-    SyntheticDataGenerateRequest:
-      additionalProperties: false
-      properties:
-        dialogs:
-          items:
-            $ref: '#/components/schemas/Message'
-          type: array
-        filtering_function:
-          enum:
-          - none
-          - random
-          - top_k
-          - top_p
-          - top_k_top_p
-          - sigmoid
-          title: The type of filtering function.
-          type: string
-        model:
-          type: string
-      required:
-      - dialogs
-      - filtering_function
-      type: object
-    SyntheticDataGenerationResponse:
-      additionalProperties: false
-      properties:
-        statistics:
+        hyperparam_search_config:
+          type: object
           additionalProperties:
             oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        synthetic_data:
-          items:
-            additionalProperties:
-              oneOf:
               - type: boolean
               - type: number
               - type: string
               - type: array
               - type: object
+        logger_config:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
+        model:
+          type: string
+        checkpoint_dir:
+          type: string
+        algorithm_config:
+          $ref: '#/components/schemas/AlgorithmConfig'
+      additionalProperties: false
+      required:
+        - job_uuid
+        - training_config
+        - hyperparam_search_config
+        - logger_config
+        - model
+    SyntheticDataGenerateRequest:
+      type: object
+      properties:
+        dialogs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+        filtering_function:
+          type: string
+          enum:
+            - none
+            - random
+            - top_k
+            - top_p
+            - top_k_top_p
+            - sigmoid
+          description: The type of filtering function.
+        model:
+          type: string
+      additionalProperties: false
+      required:
+        - dialogs
+        - filtering_function
+    SyntheticDataGenerationResponse:
+      type: object
+      properties:
+        synthetic_data:
+          type: array
+          items:
             type: object
-          type: array
-      required:
-      - synthetic_data
-      title: Response from the synthetic data generation. Batch of (prompt, response,
-        score) tuples that pass the threshold.
-      type: object
-    SystemMessage:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        role:
-          const: system
-          default: system
-          type: string
-      required:
-      - role
-      - content
-      type: object
-    TextContentItem:
-      additionalProperties: false
-      properties:
-        text:
-          type: string
-        type:
-          const: text
-          default: text
-          type: string
-      required:
-      - type
-      - text
-      type: object
-    TextDelta:
-      additionalProperties: false
-      properties:
-        text:
-          type: string
-        type:
-          const: text
-          default: text
-          type: string
-      required:
-      - type
-      - text
-      type: object
-    TokenLogProbs:
-      additionalProperties: false
-      properties:
-        logprobs_by_token:
-          additionalProperties:
-            type: number
-          type: object
-      required:
-      - logprobs_by_token
-      type: object
-    Tool:
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        identifier:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        parameters:
-          items:
-            $ref: '#/components/schemas/ToolParameter'
-          type: array
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        tool_host:
-          $ref: '#/components/schemas/ToolHost'
-        toolgroup_id:
-          type: string
-        type:
-          const: tool
-          default: tool
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - toolgroup_id
-      - tool_host
-      - description
-      - parameters
-      type: object
-    ToolCall:
-      additionalProperties: false
-      properties:
-        arguments:
-          additionalProperties:
-            oneOf:
-            - type: string
-            - type: integer
-            - type: number
-            - type: boolean
-            - items:
-                oneOf:
-                - type: string
-                - type: integer
-                - type: number
+            additionalProperties:
+              oneOf:
                 - type: boolean
-              type: array
-            - additionalProperties:
-                oneOf:
-                - type: string
-                - type: integer
                 - type: number
-                - type: boolean
-              type: object
-          type: object
-        call_id:
-          type: string
-        tool_name:
-          oneOf:
-          - $ref: '#/components/schemas/BuiltinTool'
-          - type: string
-      required:
-      - call_id
-      - tool_name
-      - arguments
-      type: object
-    ToolCallDelta:
-      additionalProperties: false
-      properties:
-        parse_status:
-          $ref: '#/components/schemas/ToolCallParseStatus'
-        tool_call:
-          oneOf:
-          - type: string
-          - $ref: '#/components/schemas/ToolCall'
-        type:
-          const: tool_call
-          default: tool_call
-          type: string
-      required:
-      - type
-      - tool_call
-      - parse_status
-      type: object
-    ToolCallParseStatus:
-      enum:
-      - started
-      - in_progress
-      - failed
-      - succeeded
-      type: string
-    ToolChoice:
-      enum:
-      - auto
-      - required
-      type: string
-    ToolDef:
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        metadata:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        name:
-          type: string
-        parameters:
-          items:
-            $ref: '#/components/schemas/ToolParameter'
-          type: array
-      required:
-      - name
-      type: object
-    ToolDefinition:
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        parameters:
-          additionalProperties:
-            $ref: '#/components/schemas/ToolParamDefinition'
-          type: object
-        tool_name:
-          oneOf:
-          - $ref: '#/components/schemas/BuiltinTool'
-          - type: string
-      required:
-      - tool_name
-      type: object
-    ToolExecutionStep:
-      additionalProperties: false
-      properties:
-        completed_at:
-          format: date-time
-          type: string
-        started_at:
-          format: date-time
-          type: string
-        step_id:
-          type: string
-        step_type:
-          const: tool_execution
-          default: tool_execution
-          type: string
-        tool_calls:
-          items:
-            $ref: '#/components/schemas/ToolCall'
-          type: array
-        tool_responses:
-          items:
-            $ref: '#/components/schemas/ToolResponse'
-          type: array
-        turn_id:
-          type: string
-      required:
-      - turn_id
-      - step_id
-      - step_type
-      - tool_calls
-      - tool_responses
-      type: object
-    ToolGroup:
-      additionalProperties: false
-      properties:
-        args:
-          additionalProperties:
-            oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        identifier:
-          type: string
-        mcp_endpoint:
-          $ref: '#/components/schemas/URL'
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        type:
-          const: tool_group
-          default: tool_group
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      type: object
-    ToolHost:
-      enum:
-      - distribution
-      - client
-      - model_context_protocol
-      type: string
-    ToolInvocationResult:
-      additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        error_code:
-          type: integer
-        error_message:
-          type: string
-      required:
-      - content
-      type: object
-    ToolParamDefinition:
-      additionalProperties: false
-      properties:
-        default:
-          oneOf:
-          - type: boolean
-          - type: number
-          - type: string
-          - type: array
-          - type: object
-        description:
-          type: string
-        param_type:
-          type: string
-        required:
-          default: true
-          type: boolean
-      required:
-      - param_type
-      type: object
-    ToolParameter:
-      additionalProperties: false
-      properties:
-        default:
-          oneOf:
-          - type: boolean
-          - type: number
-          - type: string
-          - type: array
-          - type: object
-        description:
-          type: string
-        name:
-          type: string
-        parameter_type:
-          type: string
-        required:
-          default: true
-          type: boolean
-      required:
-      - name
-      - parameter_type
-      - description
-      - required
-      type: object
-    ToolPromptFormat:
-      description: "`json` --\n    Refers to the json format for calling tools.\n\
-        \    The json format takes the form like\n    {\n        \"type\": \"function\"\
-        ,\n        \"function\" : {\n            \"name\": \"function_name\",\n  \
-        \          \"description\": \"function_description\",\n            \"parameters\"\
-        : {...}\n        }\n    }\n\n`function_tag` --\n    This is an example of\
-        \ how you could define\n    your own user defined format for making tool calls.\n\
-        \    The function_tag format looks like this,\n    <function=function_name>(parameters)</function>\n\
-        \nThe detailed prompts for each of these formats are added to llama cli"
-      enum:
-      - json
-      - function_tag
-      - python_list
-      title: This Enum refers to the prompt format for calling custom / zero shot
-        tools
-      type: string
-    ToolResponse:
-      additionalProperties: false
-      properties:
-        call_id:
-          type: string
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        tool_name:
-          oneOf:
-          - $ref: '#/components/schemas/BuiltinTool'
-          - type: string
-      required:
-      - call_id
-      - tool_name
-      - content
-      type: object
-    ToolResponseMessage:
-      additionalProperties: false
-      properties:
-        call_id:
-          type: string
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        role:
-          const: tool
-          default: tool
-          type: string
-        tool_name:
-          oneOf:
-          - $ref: '#/components/schemas/BuiltinTool'
-          - type: string
-      required:
-      - role
-      - call_id
-      - tool_name
-      - content
-      type: object
-    TopKSamplingStrategy:
-      additionalProperties: false
-      properties:
-        top_k:
-          type: integer
-        type:
-          const: top_k
-          default: top_k
-          type: string
-      required:
-      - type
-      - top_k
-      type: object
-    TopPSamplingStrategy:
-      additionalProperties: false
-      properties:
-        temperature:
-          type: number
-        top_p:
-          default: 0.95
-          type: number
-        type:
-          const: top_p
-          default: top_p
-          type: string
-      required:
-      - type
-      type: object
-    Trace:
-      additionalProperties: false
-      properties:
-        end_time:
-          format: date-time
-          type: string
-        root_span_id:
-          type: string
-        start_time:
-          format: date-time
-          type: string
-        trace_id:
-          type: string
-      required:
-      - trace_id
-      - root_span_id
-      - start_time
-      type: object
-    TrainingConfig:
-      additionalProperties: false
-      properties:
-        data_config:
-          $ref: '#/components/schemas/DataConfig'
-        dtype:
-          default: bf16
-          type: string
-        efficiency_config:
-          $ref: '#/components/schemas/EfficiencyConfig'
-        gradient_accumulation_steps:
-          type: integer
-        max_steps_per_epoch:
-          type: integer
-        max_validation_steps:
-          type: integer
-        n_epochs:
-          type: integer
-        optimizer_config:
-          $ref: '#/components/schemas/OptimizerConfig'
-      required:
-      - n_epochs
-      - max_steps_per_epoch
-      - gradient_accumulation_steps
-      - max_validation_steps
-      - data_config
-      - optimizer_config
-      type: object
-    Turn:
-      additionalProperties: false
-      properties:
-        completed_at:
-          format: date-time
-          type: string
-        input_messages:
-          items:
-            oneOf:
-            - $ref: '#/components/schemas/UserMessage'
-            - $ref: '#/components/schemas/ToolResponseMessage'
-          type: array
-        output_attachments:
-          items:
-            additionalProperties: false
-            properties:
-              content:
-                oneOf:
                 - type: string
-                - $ref: '#/components/schemas/InterleavedContentItem'
-                - items:
-                    $ref: '#/components/schemas/InterleavedContentItem'
-                  type: array
-                - $ref: '#/components/schemas/URL'
-              mime_type:
-                type: string
-            required:
-            - content
-            - mime_type
-            type: object
-          type: array
-        output_message:
-          $ref: '#/components/schemas/CompletionMessage'
-        session_id:
-          type: string
-        started_at:
-          format: date-time
-          type: string
-        steps:
-          items:
-            discriminator:
-              mapping:
-                inference: '#/components/schemas/InferenceStep'
-                memory_retrieval: '#/components/schemas/MemoryRetrievalStep'
-                shield_call: '#/components/schemas/ShieldCallStep'
-                tool_execution: '#/components/schemas/ToolExecutionStep'
-              propertyName: step_type
-            oneOf:
-            - $ref: '#/components/schemas/InferenceStep'
-            - $ref: '#/components/schemas/ToolExecutionStep'
-            - $ref: '#/components/schemas/ShieldCallStep'
-            - $ref: '#/components/schemas/MemoryRetrievalStep'
-          type: array
-        turn_id:
-          type: string
-      required:
-      - turn_id
-      - session_id
-      - input_messages
-      - steps
-      - output_message
-      - output_attachments
-      - started_at
-      title: A single turn in an interaction with an Agentic System.
-      type: object
-    URL:
-      additionalProperties: false
-      properties:
-        uri:
-          type: string
-      required:
-      - uri
-      type: object
-    UnionType:
-      additionalProperties: false
-      properties:
-        type:
-          const: union
-          default: union
-          type: string
-      required:
-      - type
-      type: object
-    UnstructuredLogEvent:
-      additionalProperties: false
-      properties:
-        attributes:
+                - type: array
+                - type: object
+        statistics:
+          type: object
           additionalProperties:
             oneOf:
-            - type: boolean
-            - type: number
-            - type: string
-            - type: array
-            - type: object
-          type: object
-        message:
-          type: string
-        severity:
-          $ref: '#/components/schemas/LogSeverity'
-        span_id:
-          type: string
-        timestamp:
-          format: date-time
-          type: string
-        trace_id:
-          type: string
-        type:
-          const: unstructured_log
-          default: unstructured_log
-          type: string
-      required:
-      - trace_id
-      - span_id
-      - timestamp
-      - type
-      - message
-      - severity
-      type: object
-    UserMessage:
+              - type: boolean
+              - type: number
+              - type: string
+              - type: array
+              - type: object
       additionalProperties: false
-      properties:
-        content:
-          $ref: '#/components/schemas/InterleavedContent'
-        context:
-          $ref: '#/components/schemas/InterleavedContent'
-        role:
-          const: user
-          default: user
-          type: string
       required:
-      - role
-      - content
-      type: object
-    VectorDB:
-      additionalProperties: false
-      properties:
-        embedding_dimension:
-          type: integer
-        embedding_model:
-          type: string
-        identifier:
-          type: string
-        provider_id:
-          type: string
-        provider_resource_id:
-          type: string
-        type:
-          const: vector_db
-          default: vector_db
-          type: string
-      required:
-      - identifier
-      - provider_resource_id
-      - provider_id
-      - type
-      - embedding_model
-      - embedding_dimension
-      type: object
+        - synthetic_data
+      description: >-
+        Response from the synthetic data generation. Batch of (prompt, response, score)
+        tuples that pass the threshold.
     VersionInfo:
-      additionalProperties: false
+      type: object
       properties:
         version:
           type: string
+      additionalProperties: false
       required:
-      - version
-      type: object
-    ViolationLevel:
-      enum:
-      - info
-      - warn
-      - error
-      type: string
-info:
-  description: "This is the specification of the Llama Stack that provides\n     \
-    \           a set of endpoints and their corresponding interfaces that are tailored\
-    \ to\n                best leverage Llama Models."
-  title: Llama Stack Specification
-  version: v1
-jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
-openapi: 3.1.0
-paths:
-  /v1/agents:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateAgentRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AgentCreateResponse'
-          description: OK
-      tags:
-      - Agents
-  /v1/agents/{agent_id}:
-    delete:
-      parameters:
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Agents
-  /v1/agents/{agent_id}/session:
-    post:
-      parameters:
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateAgentSessionRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AgentSessionCreateResponse'
-          description: OK
-      tags:
-      - Agents
-  /v1/agents/{agent_id}/session/{session_id}:
-    delete:
-      parameters:
-      - in: path
-        name: session_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Agents
-    get:
-      parameters:
-      - in: path
-        name: session_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: turn_ids
-        required: false
-        schema:
-          items:
-            type: string
-          type: array
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Session'
-          description: OK
-      tags:
-      - Agents
-  /v1/agents/{agent_id}/session/{session_id}/turn:
-    post:
-      parameters:
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: session_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateAgentTurnRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            text/event-stream:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/Turn'
-                - $ref: '#/components/schemas/AgentTurnResponseStreamChunk'
-          description: A single turn in an interaction with an Agentic System. **OR**
-            streamed agent turn completion response.
-      tags:
-      - Agents
-  /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}:
-    get:
-      parameters:
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: session_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: turn_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Turn'
-          description: OK
-      tags:
-      - Agents
-  /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}/step/{step_id}:
-    get:
-      parameters:
-      - in: path
-        name: agent_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: session_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: turn_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: step_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AgentStepResponse'
-          description: OK
-      tags:
-      - Agents
-  /v1/batch-inference/chat-completion:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/BatchChatCompletionRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BatchChatCompletionResponse'
-          description: OK
-      tags:
-      - BatchInference (Coming Soon)
-  /v1/batch-inference/completion:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/BatchCompletionRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BatchCompletionResponse'
-          description: OK
-      tags:
-      - BatchInference (Coming Soon)
-  /v1/datasetio/rows:
-    get:
-      parameters:
-      - in: query
-        name: dataset_id
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: rows_in_page
-        required: true
-        schema:
-          type: integer
-      - in: query
-        name: page_token
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: filter_condition
-        required: false
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedRowsResult'
-          description: OK
-      tags:
-      - DatasetIO
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AppendRowsRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - DatasetIO
-  /v1/datasets:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListDatasetsResponse'
-          description: OK
-      tags:
-      - Datasets
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterDatasetRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Datasets
-  /v1/datasets/{dataset_id}:
-    delete:
-      parameters:
-      - in: path
-        name: dataset_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Datasets
-    get:
-      parameters:
-      - in: path
-        name: dataset_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/Dataset'
-          description: OK
-      tags:
-      - Datasets
-  /v1/eval-tasks:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListEvalTasksResponse'
-          description: OK
-      tags:
-      - EvalTasks
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterEvalTaskRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - EvalTasks
-  /v1/eval-tasks/{eval_task_id}:
-    get:
-      parameters:
-      - in: path
-        name: eval_task_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/EvalTask'
-          description: OK
-      tags:
-      - EvalTasks
-  /v1/eval/tasks/{task_id}/evaluations:
-    post:
-      parameters:
-      - in: path
-        name: task_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EvaluateRowsRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EvaluateResponse'
-          description: OK
-      tags:
-      - Eval
-  /v1/eval/tasks/{task_id}/jobs:
-    post:
-      parameters:
-      - in: path
-        name: task_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RunEvalRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Job'
-          description: OK
-      tags:
-      - Eval
-  /v1/eval/tasks/{task_id}/jobs/{job_id}:
-    delete:
-      parameters:
-      - in: path
-        name: task_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: job_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Eval
-    get:
-      parameters:
-      - in: path
-        name: task_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: job_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/JobStatus'
-          description: OK
-      tags:
-      - Eval
-  /v1/eval/tasks/{task_id}/jobs/{job_id}/result:
-    get:
-      parameters:
-      - in: path
-        name: job_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: task_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EvaluateResponse'
-          description: OK
-      tags:
-      - Eval
-  /v1/health:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HealthInfo'
-          description: OK
-      tags:
-      - Inspect
-  /v1/inference/chat-completion:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ChatCompletionRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            text/event-stream:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/ChatCompletionResponse'
-                - $ref: '#/components/schemas/ChatCompletionResponseStreamChunk'
-          description: Chat completion response. **OR** SSE-stream of these events.
-      tags:
-      - Inference
-  /v1/inference/completion:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CompletionRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            text/event-stream:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/CompletionResponse'
-                - $ref: '#/components/schemas/CompletionResponseStreamChunk'
-          description: Completion response. **OR** streamed completion response.
-      tags:
-      - Inference
-  /v1/inference/embeddings:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EmbeddingsRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EmbeddingsResponse'
-          description: OK
-      tags:
-      - Inference
-  /v1/inspect/providers:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListProvidersResponse'
-          description: OK
-      tags:
-      - Inspect
-  /v1/inspect/routes:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListRoutesResponse'
-          description: OK
-      tags:
-      - Inspect
-  /v1/models:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListModelsResponse'
-          description: OK
-      tags:
-      - Models
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterModelRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Model'
-          description: OK
-      tags:
-      - Models
-  /v1/models/{model_id}:
-    delete:
-      parameters:
-      - in: path
-        name: model_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Models
-    get:
-      parameters:
-      - in: path
-        name: model_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/Model'
-          description: OK
-      tags:
-      - Models
-  /v1/post-training/job/artifacts:
-    get:
-      parameters:
-      - in: query
-        name: job_uuid
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/PostTrainingJobArtifactsResponse'
-          description: OK
-      tags:
-      - PostTraining (Coming Soon)
-  /v1/post-training/job/cancel:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CancelTrainingJobRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - PostTraining (Coming Soon)
-  /v1/post-training/job/status:
-    get:
-      parameters:
-      - in: query
-        name: job_uuid
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/PostTrainingJobStatusResponse'
-          description: OK
-      tags:
-      - PostTraining (Coming Soon)
-  /v1/post-training/jobs:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListPostTrainingJobsResponse'
-          description: OK
-      tags:
-      - PostTraining (Coming Soon)
-  /v1/post-training/preference-optimize:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PreferenceOptimizeRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostTrainingJob'
-          description: OK
-      tags:
-      - PostTraining (Coming Soon)
-  /v1/post-training/supervised-fine-tune:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SupervisedFineTuneRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostTrainingJob'
-          description: OK
-      tags:
-      - PostTraining (Coming Soon)
-  /v1/safety/run-shield:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RunShieldRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RunShieldResponse'
-          description: OK
-      tags:
-      - Safety
-  /v1/scoring-functions:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListScoringFunctionsResponse'
-          description: OK
-      tags:
-      - ScoringFunctions
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterScoringFunctionRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - ScoringFunctions
-  /v1/scoring-functions/{scoring_fn_id}:
-    get:
-      parameters:
-      - in: path
-        name: scoring_fn_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/ScoringFn'
-          description: OK
-      tags:
-      - ScoringFunctions
-  /v1/scoring/score:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScoreRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScoreResponse'
-          description: OK
-      tags:
-      - Scoring
-  /v1/scoring/score-batch:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScoreBatchRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScoreBatchResponse'
-          description: OK
-      tags:
-      - Scoring
-  /v1/shields:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListShieldsResponse'
-          description: OK
-      tags:
-      - Shields
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterShieldRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Shield'
-          description: OK
-      tags:
-      - Shields
-  /v1/shields/{identifier}:
-    get:
-      parameters:
-      - in: path
-        name: identifier
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/Shield'
-          description: OK
-      tags:
-      - Shields
-  /v1/synthetic-data-generation/generate:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SyntheticDataGenerateRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SyntheticDataGenerationResponse'
-          description: OK
-      tags:
-      - SyntheticDataGeneration (Coming Soon)
-  /v1/telemetry/events:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LogEventRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/spans:
-    get:
-      parameters:
-      - in: query
-        name: attribute_filters
-        required: true
-        schema:
-          items:
-            $ref: '#/components/schemas/QueryCondition'
-          type: array
-      - in: query
-        name: attributes_to_return
-        required: true
-        schema:
-          items:
-            type: string
-          type: array
-      - in: query
-        name: max_depth
-        required: false
-        schema:
-          type: integer
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QuerySpansResponse'
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/spans/export:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SaveSpansToDatasetRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/spans/{span_id}/tree:
-    get:
-      parameters:
-      - in: path
-        name: span_id
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: attributes_to_return
-        required: false
-        schema:
-          items:
-            type: string
-          type: array
-      - in: query
-        name: max_depth
-        required: false
-        schema:
-          type: integer
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QuerySpanTreeResponse'
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/traces:
-    get:
-      parameters:
-      - in: query
-        name: attribute_filters
-        required: false
-        schema:
-          items:
-            $ref: '#/components/schemas/QueryCondition'
-          type: array
-      - in: query
-        name: limit
-        required: false
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        required: false
-        schema:
-          type: integer
-      - in: query
-        name: order_by
-        required: false
-        schema:
-          items:
-            type: string
-          type: array
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueryTracesResponse'
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/traces/{trace_id}:
-    get:
-      parameters:
-      - in: path
-        name: trace_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Trace'
-          description: OK
-      tags:
-      - Telemetry
-  /v1/telemetry/traces/{trace_id}/spans/{span_id}:
-    get:
-      parameters:
-      - in: path
-        name: trace_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: span_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Span'
-          description: OK
-      tags:
-      - Telemetry
-  /v1/tool-runtime/invoke:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/InvokeToolRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ToolInvocationResult'
-          description: OK
-      summary: Run a tool with the given arguments
-      tags:
-      - ToolRuntime
-  /v1/tool-runtime/list-tools:
-    get:
-      parameters:
-      - in: query
-        name: tool_group_id
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: mcp_endpoint
-        required: false
-        schema:
-          $ref: '#/components/schemas/URL'
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/jsonl:
-              schema:
-                $ref: '#/components/schemas/ToolDef'
-          description: OK
-      tags:
-      - ToolRuntime
-  /v1/tool-runtime/rag-tool/insert:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/InsertRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      summary: Index documents so they can be used by the RAG system
-      tags:
-      - ToolRuntime
-  /v1/tool-runtime/rag-tool/query:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/QueryRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RAGQueryResult'
-          description: OK
-      summary: Query the RAG system for context; typically invoked by the agent
-      tags:
-      - ToolRuntime
-  /v1/toolgroups:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListToolGroupsResponse'
-          description: OK
-      summary: List tool groups with optional provider
-      tags:
-      - ToolGroups
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterToolGroupRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      summary: Register a tool group
-      tags:
-      - ToolGroups
-  /v1/toolgroups/{toolgroup_id}:
-    delete:
-      parameters:
-      - in: path
-        name: toolgroup_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      summary: Unregister a tool group
-      tags:
-      - ToolGroups
-    get:
-      parameters:
-      - in: path
-        name: toolgroup_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ToolGroup'
-          description: OK
-      tags:
-      - ToolGroups
-  /v1/tools:
-    get:
-      parameters:
-      - in: query
-        name: toolgroup_id
-        required: false
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListToolsResponse'
-          description: OK
-      summary: List tools with optional tool group
-      tags:
-      - ToolGroups
-  /v1/tools/{tool_name}:
-    get:
-      parameters:
-      - in: path
-        name: tool_name
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Tool'
-          description: OK
-      tags:
-      - ToolGroups
-  /v1/vector-dbs:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListVectorDBsResponse'
-          description: OK
-      tags:
-      - VectorDBs
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegisterVectorDbRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VectorDB'
-          description: OK
-      tags:
-      - VectorDBs
-  /v1/vector-dbs/{vector_db_id}:
-    delete:
-      parameters:
-      - in: path
-        name: vector_db_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-      tags:
-      - VectorDBs
-    get:
-      parameters:
-      - in: path
-        name: vector_db_id
-        required: true
-        schema:
-          type: string
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                oneOf:
-                - $ref: '#/components/schemas/VectorDB'
-          description: OK
-      tags:
-      - VectorDBs
-  /v1/vector-io/insert:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/InsertChunksRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-      tags:
-      - VectorIO
-  /v1/vector-io/query:
-    post:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/QueryChunksRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueryChunksResponse'
-          description: OK
-      tags:
-      - VectorIO
-  /v1/version:
-    get:
-      parameters:
-      - description: JSON-encoded provider data which will be made available to the
-          adapter servicing the API
-        in: header
-        name: X-LlamaStack-Provider-Data
-        required: false
-        schema:
-          type: string
-      - description: Version of the client making the request. This is used to ensure
-          that the client and server are compatible.
-        in: header
-        name: X-LlamaStack-Client-Version
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VersionInfo'
-          description: OK
-      tags:
-      - Inspect
-servers:
-- url: http://any-hosted-llama-stack.com
+        - version
+  responses: {}
 tags:
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentCandidate" />
-  name: AgentCandidate
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentConfig" />
-  name: AgentConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentCreateResponse"
-    />
-  name: AgentCreateResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentSessionCreateResponse"
-    />
-  name: AgentSessionCreateResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentStepResponse"
-    />
-  name: AgentStepResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTool" />
-  name: AgentTool
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnInputType"
-    />
-  name: AgentTurnInputType
-- description: 'Streamed agent execution response.
+  - name: Agents
+    description: >-
+      Main functionalities provided by this API:
 
+      - Create agents with specific instructions and ability to use tools.
 
-    <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseEvent" />'
-  name: AgentTurnResponseEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepCompletePayload"
-    />
-  name: AgentTurnResponseStepCompletePayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepProgressPayload"
-    />
-  name: AgentTurnResponseStepProgressPayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStepStartPayload"
-    />
-  name: AgentTurnResponseStepStartPayload
-- description: 'streamed agent turn completion response.
+      - Interactions with agents are grouped into sessions ("threads"), and each interaction
+      is called a "turn".
 
+      - Agents can be provided with various tools (see the ToolGroups and ToolRuntime
+      APIs for more details).
 
-    <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseStreamChunk"
-    />'
-  name: AgentTurnResponseStreamChunk
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnCompletePayload"
-    />
-  name: AgentTurnResponseTurnCompletePayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/AgentTurnResponseTurnStartPayload"
-    />
-  name: AgentTurnResponseTurnStartPayload
-- name: Agents
-- description: <SchemaDefinition schemaRef="#/components/schemas/AggregationFunctionType"
-    />
-  name: AggregationFunctionType
-- description: <SchemaDefinition schemaRef="#/components/schemas/AppEvalTaskConfig"
-    />
-  name: AppEvalTaskConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/AppendRowsRequest"
-    />
-  name: AppendRowsRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ArrayType" />
-  name: ArrayType
-- description: <SchemaDefinition schemaRef="#/components/schemas/BasicScoringFnParams"
-    />
-  name: BasicScoringFnParams
-- description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionRequest"
-    />
-  name: BatchChatCompletionRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/BatchChatCompletionResponse"
-    />
-  name: BatchChatCompletionResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionRequest"
-    />
-  name: BatchCompletionRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/BatchCompletionResponse"
-    />
-  name: BatchCompletionResponse
-- name: BatchInference (Coming Soon)
-- description: <SchemaDefinition schemaRef="#/components/schemas/BenchmarkEvalTaskConfig"
-    />
-  name: BenchmarkEvalTaskConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/BooleanType" />
-  name: BooleanType
-- description: <SchemaDefinition schemaRef="#/components/schemas/BuiltinTool" />
-  name: BuiltinTool
-- description: <SchemaDefinition schemaRef="#/components/schemas/CancelTrainingJobRequest"
-    />
-  name: CancelTrainingJobRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionInputType"
-    />
-  name: ChatCompletionInputType
-- description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionRequest"
-    />
-  name: ChatCompletionRequest
-- description: 'Chat completion response.
+      - Agents can be provided with various shields (see the Safety API for more details).
 
+      - Agents can also use Memory to retrieve information from knowledge bases. See
+      the RAG Tool and Vector IO APIs for more details.
+    x-displayName: >-
+      Agents API for creating and interacting with agentic systems.
+  - name: BatchInference (Coming Soon)
+  - name: Benchmarks
+  - name: DatasetIO
+  - name: Datasets
+  - name: Eval
+  - name: Inference
+    description: >-
+      This API provides the raw interface to the underlying models. Two kinds of models
+      are supported:
 
-    <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponse" />'
-  name: ChatCompletionResponse
-- description: 'Chat completion response event.
+      - LLM models: these models generate "raw" and "chat" (conversational) completions.
 
-
-    <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponseEvent"
-    />'
-  name: ChatCompletionResponseEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponseEventType"
-    />
-  name: ChatCompletionResponseEventType
-- description: 'SSE-stream of these events.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/ChatCompletionResponseStreamChunk"
-    />'
-  name: ChatCompletionResponseStreamChunk
-- description: 'Checkpoint created during training runs
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/Checkpoint" />'
-  name: Checkpoint
-- description: <SchemaDefinition schemaRef="#/components/schemas/CompletionInputType"
-    />
-  name: CompletionInputType
-- description: <SchemaDefinition schemaRef="#/components/schemas/CompletionMessage"
-    />
-  name: CompletionMessage
-- description: <SchemaDefinition schemaRef="#/components/schemas/CompletionRequest"
-    />
-  name: CompletionRequest
-- description: 'Completion response.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/CompletionResponse" />'
-  name: CompletionResponse
-- description: 'streamed completion response.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/CompletionResponseStreamChunk"
-    />'
-  name: CompletionResponseStreamChunk
-- description: <SchemaDefinition schemaRef="#/components/schemas/ContentDelta" />
-  name: ContentDelta
-- description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentRequest"
-    />
-  name: CreateAgentRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentSessionRequest"
-    />
-  name: CreateAgentSessionRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/CreateAgentTurnRequest"
-    />
-  name: CreateAgentTurnRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/DPOAlignmentConfig"
-    />
-  name: DPOAlignmentConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/DataConfig" />
-  name: DataConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/Dataset" />
-  name: Dataset
-- description: <SchemaDefinition schemaRef="#/components/schemas/DatasetFormat" />
-  name: DatasetFormat
-- name: DatasetIO
-- name: Datasets
-- description: <SchemaDefinition schemaRef="#/components/schemas/DefaultRAGQueryGeneratorConfig"
-    />
-  name: DefaultRAGQueryGeneratorConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/EfficiencyConfig"
-    />
-  name: EfficiencyConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsRequest"
-    />
-  name: EmbeddingsRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/EmbeddingsResponse"
-    />
-  name: EmbeddingsResponse
-- name: Eval
-- description: <SchemaDefinition schemaRef="#/components/schemas/EvalTask" />
-  name: EvalTask
-- name: EvalTasks
-- description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateResponse"
-    />
-  name: EvaluateResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/EvaluateRowsRequest"
-    />
-  name: EvaluateRowsRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/GrammarResponseFormat"
-    />
-  name: GrammarResponseFormat
-- description: <SchemaDefinition schemaRef="#/components/schemas/GreedySamplingStrategy"
-    />
-  name: GreedySamplingStrategy
-- description: <SchemaDefinition schemaRef="#/components/schemas/HealthInfo" />
-  name: HealthInfo
-- description: <SchemaDefinition schemaRef="#/components/schemas/ImageContentItem"
-    />
-  name: ImageContentItem
-- description: <SchemaDefinition schemaRef="#/components/schemas/ImageDelta" />
-  name: ImageDelta
-- name: Inference
-- description: <SchemaDefinition schemaRef="#/components/schemas/InferenceStep" />
-  name: InferenceStep
-- description: <SchemaDefinition schemaRef="#/components/schemas/InsertChunksRequest"
-    />
-  name: InsertChunksRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/InsertRequest" />
-  name: InsertRequest
-- name: Inspect
-- description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContent"
-    />
-  name: InterleavedContent
-- description: <SchemaDefinition schemaRef="#/components/schemas/InterleavedContentItem"
-    />
-  name: InterleavedContentItem
-- description: <SchemaDefinition schemaRef="#/components/schemas/InvokeToolRequest"
-    />
-  name: InvokeToolRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/Job" />
-  name: Job
-- description: <SchemaDefinition schemaRef="#/components/schemas/JobStatus" />
-  name: JobStatus
-- description: <SchemaDefinition schemaRef="#/components/schemas/JsonSchemaResponseFormat"
-    />
-  name: JsonSchemaResponseFormat
-- description: <SchemaDefinition schemaRef="#/components/schemas/JsonType" />
-  name: JsonType
-- description: <SchemaDefinition schemaRef="#/components/schemas/LLMAsJudgeScoringFnParams"
-    />
-  name: LLMAsJudgeScoringFnParams
-- description: <SchemaDefinition schemaRef="#/components/schemas/LLMRAGQueryGeneratorConfig"
-    />
-  name: LLMRAGQueryGeneratorConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListDatasetsResponse"
-    />
-  name: ListDatasetsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListEvalTasksResponse"
-    />
-  name: ListEvalTasksResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListModelsResponse"
-    />
-  name: ListModelsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListPostTrainingJobsResponse"
-    />
-  name: ListPostTrainingJobsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListProvidersResponse"
-    />
-  name: ListProvidersResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListRoutesResponse"
-    />
-  name: ListRoutesResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListScoringFunctionsResponse"
-    />
-  name: ListScoringFunctionsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListShieldsResponse"
-    />
-  name: ListShieldsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListToolGroupsResponse"
-    />
-  name: ListToolGroupsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListToolsResponse"
-    />
-  name: ListToolsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ListVectorDBsResponse"
-    />
-  name: ListVectorDBsResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/LogEventRequest"
-    />
-  name: LogEventRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/LogSeverity" />
-  name: LogSeverity
-- description: <SchemaDefinition schemaRef="#/components/schemas/LoraFinetuningConfig"
-    />
-  name: LoraFinetuningConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/MemoryRetrievalStep"
-    />
-  name: MemoryRetrievalStep
-- description: <SchemaDefinition schemaRef="#/components/schemas/Message" />
-  name: Message
-- description: <SchemaDefinition schemaRef="#/components/schemas/MetricEvent" />
-  name: MetricEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/Model" />
-  name: Model
-- description: <SchemaDefinition schemaRef="#/components/schemas/ModelCandidate" />
-  name: ModelCandidate
-- description: <SchemaDefinition schemaRef="#/components/schemas/ModelType" />
-  name: ModelType
-- name: Models
-- description: <SchemaDefinition schemaRef="#/components/schemas/NumberType" />
-  name: NumberType
-- description: <SchemaDefinition schemaRef="#/components/schemas/ObjectType" />
-  name: ObjectType
-- description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerConfig"
-    />
-  name: OptimizerConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/OptimizerType" />
-  name: OptimizerType
-- description: <SchemaDefinition schemaRef="#/components/schemas/PaginatedRowsResult"
-    />
-  name: PaginatedRowsResult
-- description: <SchemaDefinition schemaRef="#/components/schemas/ParamType" />
-  name: ParamType
-- name: PostTraining (Coming Soon)
-- description: <SchemaDefinition schemaRef="#/components/schemas/PostTrainingJob"
-    />
-  name: PostTrainingJob
-- description: 'Artifacts of a finetuning job.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/PostTrainingJobArtifactsResponse"
-    />'
-  name: PostTrainingJobArtifactsResponse
-- description: 'Status of a finetuning job.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/PostTrainingJobStatusResponse"
-    />'
-  name: PostTrainingJobStatusResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/PreferenceOptimizeRequest"
-    />
-  name: PreferenceOptimizeRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ProviderInfo" />
-  name: ProviderInfo
-- description: <SchemaDefinition schemaRef="#/components/schemas/QATFinetuningConfig"
-    />
-  name: QATFinetuningConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksRequest"
-    />
-  name: QueryChunksRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryChunksResponse"
-    />
-  name: QueryChunksResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryCondition" />
-  name: QueryCondition
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryConditionOp"
-    />
-  name: QueryConditionOp
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryRequest" />
-  name: QueryRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpanTreeResponse"
-    />
-  name: QuerySpanTreeResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/QuerySpansResponse"
-    />
-  name: QuerySpansResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/QueryTracesResponse"
-    />
-  name: QueryTracesResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/RAGDocument" />
-  name: RAGDocument
-- description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryConfig" />
-  name: RAGQueryConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryGeneratorConfig"
-    />
-  name: RAGQueryGeneratorConfig
-- description: <SchemaDefinition schemaRef="#/components/schemas/RAGQueryResult" />
-  name: RAGQueryResult
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegexParserScoringFnParams"
-    />
-  name: RegexParserScoringFnParams
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterDatasetRequest"
-    />
-  name: RegisterDatasetRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterEvalTaskRequest"
-    />
-  name: RegisterEvalTaskRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterModelRequest"
-    />
-  name: RegisterModelRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterScoringFunctionRequest"
-    />
-  name: RegisterScoringFunctionRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterShieldRequest"
-    />
-  name: RegisterShieldRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterToolGroupRequest"
-    />
-  name: RegisterToolGroupRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RegisterVectorDbRequest"
-    />
-  name: RegisterVectorDbRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ResponseFormat" />
-  name: ResponseFormat
-- description: <SchemaDefinition schemaRef="#/components/schemas/RouteInfo" />
-  name: RouteInfo
-- description: <SchemaDefinition schemaRef="#/components/schemas/RunEvalRequest" />
-  name: RunEvalRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldRequest"
-    />
-  name: RunShieldRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/RunShieldResponse"
-    />
-  name: RunShieldResponse
-- name: Safety
-- description: <SchemaDefinition schemaRef="#/components/schemas/SafetyViolation"
-    />
-  name: SafetyViolation
-- description: <SchemaDefinition schemaRef="#/components/schemas/SamplingParams" />
-  name: SamplingParams
-- description: <SchemaDefinition schemaRef="#/components/schemas/SaveSpansToDatasetRequest"
-    />
-  name: SaveSpansToDatasetRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchRequest"
-    />
-  name: ScoreBatchRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoreBatchResponse"
-    />
-  name: ScoreBatchResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoreRequest" />
-  name: ScoreRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoreResponse" />
-  name: ScoreResponse
-- name: Scoring
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoringFn" />
-  name: ScoringFn
-- name: ScoringFunctions
-- description: <SchemaDefinition schemaRef="#/components/schemas/ScoringResult" />
-  name: ScoringResult
-- description: 'A single session of an interaction with an Agentic System.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/Session" />'
-  name: Session
-- description: 'A safety shield resource that can be used to check content
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/Shield" />'
-  name: Shield
-- description: <SchemaDefinition schemaRef="#/components/schemas/ShieldCallStep" />
-  name: ShieldCallStep
-- name: Shields
-- description: <SchemaDefinition schemaRef="#/components/schemas/Span" />
-  name: Span
-- description: <SchemaDefinition schemaRef="#/components/schemas/SpanEndPayload" />
-  name: SpanEndPayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/SpanStartPayload"
-    />
-  name: SpanStartPayload
-- description: <SchemaDefinition schemaRef="#/components/schemas/SpanStatus" />
-  name: SpanStatus
-- description: <SchemaDefinition schemaRef="#/components/schemas/SpanWithStatus" />
-  name: SpanWithStatus
-- description: <SchemaDefinition schemaRef="#/components/schemas/StopReason" />
-  name: StopReason
-- description: <SchemaDefinition schemaRef="#/components/schemas/StringType" />
-  name: StringType
-- description: <SchemaDefinition schemaRef="#/components/schemas/StructuredLogEvent"
-    />
-  name: StructuredLogEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/SupervisedFineTuneRequest"
-    />
-  name: SupervisedFineTuneRequest
-- description: <SchemaDefinition schemaRef="#/components/schemas/SyntheticDataGenerateRequest"
-    />
-  name: SyntheticDataGenerateRequest
-- name: SyntheticDataGeneration (Coming Soon)
-- description: 'Response from the synthetic data generation. Batch of (prompt, response,
-    score) tuples that pass the threshold.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/SyntheticDataGenerationResponse"
-    />'
-  name: SyntheticDataGenerationResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/SystemMessage" />
-  name: SystemMessage
-- name: Telemetry
-- description: <SchemaDefinition schemaRef="#/components/schemas/TextContentItem"
-    />
-  name: TextContentItem
-- description: <SchemaDefinition schemaRef="#/components/schemas/TextDelta" />
-  name: TextDelta
-- description: <SchemaDefinition schemaRef="#/components/schemas/TokenLogProbs" />
-  name: TokenLogProbs
-- description: <SchemaDefinition schemaRef="#/components/schemas/Tool" />
-  name: Tool
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolCall" />
-  name: ToolCall
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallDelta" />
-  name: ToolCallDelta
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolCallParseStatus"
-    />
-  name: ToolCallParseStatus
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolChoice" />
-  name: ToolChoice
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolDef" />
-  name: ToolDef
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolDefinition" />
-  name: ToolDefinition
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolExecutionStep"
-    />
-  name: ToolExecutionStep
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolGroup" />
-  name: ToolGroup
-- name: ToolGroups
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolHost" />
-  name: ToolHost
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolInvocationResult"
-    />
-  name: ToolInvocationResult
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolParamDefinition"
-    />
-  name: ToolParamDefinition
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolParameter" />
-  name: ToolParameter
-- description: "This Enum refers to the prompt format for calling custom / zero shot\
-    \ tools\n\n`json` --\n    Refers to the json format for calling tools.\n    The\
-    \ json format takes the form like\n    {\n        \"type\": \"function\",\n  \
-    \      \"function\" : {\n            \"name\": \"function_name\",\n          \
-    \  \"description\": \"function_description\",\n            \"parameters\": {...}\n\
-    \        }\n    }\n\n`function_tag` --\n    This is an example of how you could\
-    \ define\n    your own user defined format for making tool calls.\n    The function_tag\
-    \ format looks like this,\n    <function=function_name>(parameters)</function>\n\
-    \nThe detailed prompts for each of these formats are added to llama cli\n\n<SchemaDefinition\
-    \ schemaRef=\"#/components/schemas/ToolPromptFormat\" />"
-  name: ToolPromptFormat
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponse" />
-  name: ToolResponse
-- description: <SchemaDefinition schemaRef="#/components/schemas/ToolResponseMessage"
-    />
-  name: ToolResponseMessage
-- name: ToolRuntime
-- description: <SchemaDefinition schemaRef="#/components/schemas/TopKSamplingStrategy"
-    />
-  name: TopKSamplingStrategy
-- description: <SchemaDefinition schemaRef="#/components/schemas/TopPSamplingStrategy"
-    />
-  name: TopPSamplingStrategy
-- description: <SchemaDefinition schemaRef="#/components/schemas/Trace" />
-  name: Trace
-- description: <SchemaDefinition schemaRef="#/components/schemas/TrainingConfig" />
-  name: TrainingConfig
-- description: 'A single turn in an interaction with an Agentic System.
-
-
-    <SchemaDefinition schemaRef="#/components/schemas/Turn" />'
-  name: Turn
-- description: <SchemaDefinition schemaRef="#/components/schemas/URL" />
-  name: URL
-- description: <SchemaDefinition schemaRef="#/components/schemas/UnionType" />
-  name: UnionType
-- description: <SchemaDefinition schemaRef="#/components/schemas/UnstructuredLogEvent"
-    />
-  name: UnstructuredLogEvent
-- description: <SchemaDefinition schemaRef="#/components/schemas/UserMessage" />
-  name: UserMessage
-- description: <SchemaDefinition schemaRef="#/components/schemas/VectorDB" />
-  name: VectorDB
-- name: VectorDBs
-- name: VectorIO
-- description: <SchemaDefinition schemaRef="#/components/schemas/VersionInfo" />
-  name: VersionInfo
-- description: <SchemaDefinition schemaRef="#/components/schemas/ViolationLevel" />
-  name: ViolationLevel
+      - Embedding models: these models generate embeddings to be used for semantic
+      search.
+    x-displayName: >-
+      Llama Stack Inference API for generating completions, chat completions, and
+      embeddings.
+  - name: Inspect
+  - name: Models
+  - name: PostTraining (Coming Soon)
+  - name: Safety
+  - name: Scoring
+  - name: ScoringFunctions
+  - name: Shields
+  - name: SyntheticDataGeneration (Coming Soon)
+  - name: Telemetry
+  - name: ToolGroups
+  - name: ToolRuntime
+  - name: VectorDBs
+  - name: VectorIO
 x-tagGroups:
-- name: Operations
-  tags:
-  - Agents
-  - BatchInference (Coming Soon)
-  - DatasetIO
-  - Datasets
-  - Eval
-  - EvalTasks
-  - Inference
-  - Inspect
-  - Models
-  - PostTraining (Coming Soon)
-  - Safety
-  - Scoring
-  - ScoringFunctions
-  - Shields
-  - SyntheticDataGeneration (Coming Soon)
-  - Telemetry
-  - ToolGroups
-  - ToolRuntime
-  - VectorDBs
-  - VectorIO
-- name: Types
-  tags:
-  - AgentCandidate
-  - AgentConfig
-  - AgentCreateResponse
-  - AgentSessionCreateResponse
-  - AgentStepResponse
-  - AgentTool
-  - AgentTurnInputType
-  - AgentTurnResponseEvent
-  - AgentTurnResponseStepCompletePayload
-  - AgentTurnResponseStepProgressPayload
-  - AgentTurnResponseStepStartPayload
-  - AgentTurnResponseStreamChunk
-  - AgentTurnResponseTurnCompletePayload
-  - AgentTurnResponseTurnStartPayload
-  - AggregationFunctionType
-  - AppEvalTaskConfig
-  - AppendRowsRequest
-  - ArrayType
-  - BasicScoringFnParams
-  - BatchChatCompletionRequest
-  - BatchChatCompletionResponse
-  - BatchCompletionRequest
-  - BatchCompletionResponse
-  - BenchmarkEvalTaskConfig
-  - BooleanType
-  - BuiltinTool
-  - CancelTrainingJobRequest
-  - ChatCompletionInputType
-  - ChatCompletionRequest
-  - ChatCompletionResponse
-  - ChatCompletionResponseEvent
-  - ChatCompletionResponseEventType
-  - ChatCompletionResponseStreamChunk
-  - Checkpoint
-  - CompletionInputType
-  - CompletionMessage
-  - CompletionRequest
-  - CompletionResponse
-  - CompletionResponseStreamChunk
-  - ContentDelta
-  - CreateAgentRequest
-  - CreateAgentSessionRequest
-  - CreateAgentTurnRequest
-  - DPOAlignmentConfig
-  - DataConfig
-  - Dataset
-  - DatasetFormat
-  - DefaultRAGQueryGeneratorConfig
-  - EfficiencyConfig
-  - EmbeddingsRequest
-  - EmbeddingsResponse
-  - EvalTask
-  - EvaluateResponse
-  - EvaluateRowsRequest
-  - GrammarResponseFormat
-  - GreedySamplingStrategy
-  - HealthInfo
-  - ImageContentItem
-  - ImageDelta
-  - InferenceStep
-  - InsertChunksRequest
-  - InsertRequest
-  - InterleavedContent
-  - InterleavedContentItem
-  - InvokeToolRequest
-  - Job
-  - JobStatus
-  - JsonSchemaResponseFormat
-  - JsonType
-  - LLMAsJudgeScoringFnParams
-  - LLMRAGQueryGeneratorConfig
-  - ListDatasetsResponse
-  - ListEvalTasksResponse
-  - ListModelsResponse
-  - ListPostTrainingJobsResponse
-  - ListProvidersResponse
-  - ListRoutesResponse
-  - ListScoringFunctionsResponse
-  - ListShieldsResponse
-  - ListToolGroupsResponse
-  - ListToolsResponse
-  - ListVectorDBsResponse
-  - LogEventRequest
-  - LogSeverity
-  - LoraFinetuningConfig
-  - MemoryRetrievalStep
-  - Message
-  - MetricEvent
-  - Model
-  - ModelCandidate
-  - ModelType
-  - NumberType
-  - ObjectType
-  - OptimizerConfig
-  - OptimizerType
-  - PaginatedRowsResult
-  - ParamType
-  - PostTrainingJob
-  - PostTrainingJobArtifactsResponse
-  - PostTrainingJobStatusResponse
-  - PreferenceOptimizeRequest
-  - ProviderInfo
-  - QATFinetuningConfig
-  - QueryChunksRequest
-  - QueryChunksResponse
-  - QueryCondition
-  - QueryConditionOp
-  - QueryRequest
-  - QuerySpanTreeResponse
-  - QuerySpansResponse
-  - QueryTracesResponse
-  - RAGDocument
-  - RAGQueryConfig
-  - RAGQueryGeneratorConfig
-  - RAGQueryResult
-  - RegexParserScoringFnParams
-  - RegisterDatasetRequest
-  - RegisterEvalTaskRequest
-  - RegisterModelRequest
-  - RegisterScoringFunctionRequest
-  - RegisterShieldRequest
-  - RegisterToolGroupRequest
-  - RegisterVectorDbRequest
-  - ResponseFormat
-  - RouteInfo
-  - RunEvalRequest
-  - RunShieldRequest
-  - RunShieldResponse
-  - SafetyViolation
-  - SamplingParams
-  - SaveSpansToDatasetRequest
-  - ScoreBatchRequest
-  - ScoreBatchResponse
-  - ScoreRequest
-  - ScoreResponse
-  - ScoringFn
-  - ScoringResult
-  - Session
-  - Shield
-  - ShieldCallStep
-  - Span
-  - SpanEndPayload
-  - SpanStartPayload
-  - SpanStatus
-  - SpanWithStatus
-  - StopReason
-  - StringType
-  - StructuredLogEvent
-  - SupervisedFineTuneRequest
-  - SyntheticDataGenerateRequest
-  - SyntheticDataGenerationResponse
-  - SystemMessage
-  - TextContentItem
-  - TextDelta
-  - TokenLogProbs
-  - Tool
-  - ToolCall
-  - ToolCallDelta
-  - ToolCallParseStatus
-  - ToolChoice
-  - ToolDef
-  - ToolDefinition
-  - ToolExecutionStep
-  - ToolGroup
-  - ToolHost
-  - ToolInvocationResult
-  - ToolParamDefinition
-  - ToolParameter
-  - ToolPromptFormat
-  - ToolResponse
-  - ToolResponseMessage
-  - TopKSamplingStrategy
-  - TopPSamplingStrategy
-  - Trace
-  - TrainingConfig
-  - Turn
-  - URL
-  - UnionType
-  - UnstructuredLogEvent
-  - UserMessage
-  - VectorDB
-  - VersionInfo
-  - ViolationLevel
+  - name: Operations
+    tags:
+      - Agents
+      - BatchInference (Coming Soon)
+      - Benchmarks
+      - DatasetIO
+      - Datasets
+      - Eval
+      - Inference
+      - Inspect
+      - Models
+      - PostTraining (Coming Soon)
+      - Safety
+      - Scoring
+      - ScoringFunctions
+      - Shields
+      - SyntheticDataGeneration (Coming Soon)
+      - Telemetry
+      - ToolGroups
+      - ToolRuntime
+      - VectorDBs
+      - VectorIO

--- a/scripts/generate_swift_types.sh
+++ b/scripts/generate_swift_types.sh
@@ -10,7 +10,7 @@ if [ -n "$LLAMA_STACK_DIR" ]; then
   cp "$LLAMA_STACK_DIR/docs/resources/$OPENAPI_FILE" "Sources/LlamaStackClient/$OPENAPI_FILE"
 else
   echo "Using remote (main branch) Llama Stack repo"
-  URL="https://raw.githubusercontent.com/meta-llama/llama-stack/refs/heads/main/docs/resources/llama-stack-spec.yaml"
+  URL="https://raw.githubusercontent.com/meta-llama/llama-stack/refs/heads/main/docs/_static/llama-stack-spec.yaml"
   curl -s $URL > "Sources/LlamaStackClient/$OPENAPI_FILE"
 fi
 


### PR DESCRIPTION
Updated iOS SDK for Llama Stack 0.1.3 ([release](https://github.com/meta-llama/llama-stack/releases/tag/v0.1.3) and [spec](https://github.com/meta-llama/llama-stack/blob/main/docs/_static/llama-stack-spec.html)). 

Note that the two lines below generated openapi.yaml have to be deleted to avoid the Xcode build error (tested on the two updated iOS demos [here](https://github.com/meta-llama/llama-stack-apps/pull/173)).
```
security:
  - Default: []
```

<img width="1097" alt="image" src="https://github.com/user-attachments/assets/c83e09d2-647a-4e35-b718-dc9761375768" />
