### PR TITLE
added ProviderMiddleware to pass api key in X-LlamaStack-Provider-Data

### DIFF
--- a/Sources/LlamaStackClient/Inference/RemoteInference.swift
+++ b/Sources/LlamaStackClient/Inference/RemoteInference.swift
@@ -13,7 +13,7 @@ public class RemoteInference: Inference {
     self.client = Client(
       serverURL: url,
       transport: URLSessionTransport(),
-      middlewares: apiKey.map { [BearerAuthenticationMiddleware(token: $0)] } ?? []
+      middlewares: apiKey.map { [ProviderMiddleware(token: $0)] } ?? []
     )
   }
   

--- a/Sources/LlamaStackClient/ProviderMiddleware.swift
+++ b/Sources/LlamaStackClient/ProviderMiddleware.swift
@@ -1,0 +1,34 @@
+import OpenAPIRuntime
+import Foundation
+import HTTPTypes
+
+package struct ProviderMiddleware {
+    private let token: String
+    
+    package init(token: String) {
+        self.token = token
+    }
+    
+    private var providerToken: String {
+      let key_dict = ["together_api_key": token]
+      if let jsonData = try? JSONSerialization.data(withJSONObject: key_dict, options: []),
+         let jsonString = String(data: jsonData, encoding: .utf8) {
+        return jsonString
+      }
+      return ""
+  }
+}
+
+extension ProviderMiddleware: ClientMiddleware {
+    package func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String,
+        next: (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        var request = request
+        request.headerFields[HTTPField.Name("X-LlamaStack-Provider-Data")!] = providerToken
+        return try await next(request, body, baseURL)
+    }
+}


### PR DESCRIPTION
client needs to call `let inference = RemoteInference(url: URL(string: "https://llama-stack.together.ai")!, apiKey: "YOUR_TOGETHER_API_KEY")`


