### PR TITLE
Demo app move

### DIFF
--- a/examples/ios_calendar_assistant/README.md
+++ b/examples/ios_calendar_assistant/README.md
@@ -97,13 +97,12 @@ iOSCalendarAssistantWithLocalInf is a demo app that uses Llama Stack Swift SDK's
 
 1. On a Mac terminal, in your top level directory, run commands:
 ```
-git clone https://github.com/meta-llama/llama-stack-apps
 git clone https://github.com/meta-llama/llama-stack-client-swift
 cd llama-stack-client-swift
 git submodule update --init --recursive
 ```
 
-2. Open `llama-stack-apps/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj` in Xcode.
+2. Open `examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj` in Xcode.
 
 3. In the `iOSCalendarAssistantWithLocalInf` project panel, remove `LocalInferenceImpl.xcodeproj` and drag and drop `LocalInferenceImpl.xcodeproj` from `llama-stack-client-swift/local_inference` into the project - in the "Choose options for adding these files" dialog, select "Reference files in place" for Action.
 

--- a/examples/ios_calendar_assistant/README.md
+++ b/examples/ios_calendar_assistant/README.md
@@ -1,0 +1,114 @@
+# iOSCalendarAssistant
+
+iOSCalendarAssistant is a demo app ([video](https://drive.google.com/file/d/1xjdYVm3zDnlxZGi40X_D4IgvmASfG5QZ/view?usp=sharing)) that uses Llama Stack Swift SDK's remote inference and agent APIs to take a meeting transcript, summarizes it, extracts action items, and calls tools to book any followup meetings.
+
+You can also test the create calendar event with a direct ask instead of a detailed meeting note.
+
+## Installation
+
+We also have a demo project for running on-device inference. Checkout the instructions in the section `iOSCalendarAssistantWithLocalInf` below.
+
+We recommend you try the [iOS Quick Demo](../ios_quick_demo) first to confirm the prerequisite and installation - both demos have the same prerequisite and the first two installation steps.
+
+The quickest way to try out the demo for remote inference is using Together.ai's Llama Stack distro at https://llama-stack.together.ai - you can skip the next section and go to the Build and Run the iOS demo section directly.
+
+## (Optional) Build and Run Own Llama Stack Distro
+
+You need to set up a remote Llama Stack distributions to run this demo. Assuming you have a [Fireworks](https://fireworks.ai/account/api-keys) or [Together](https://api.together.ai/) API key, which you can get easily by clicking the link above:
+
+```
+conda create -n llama-stack python=3.10
+conda activate llama-stack
+pip install --no-cache llama-stack==0.1.4 llama-models==0.1.4 llama-stack-client==0.1.4
+```
+
+Then, either:
+```
+PYPI_VERSION=0.1.4 llama stack build --template fireworks --image-type conda
+export FIREWORKS_API_KEY="<your_fireworks_api_key>"
+llama stack run fireworks
+```
+or
+```
+PYPI_VERSION=0.1.4 llama stack build --template together --image-type conda
+export TOGETHER_API_KEY="<your_together_api_key>"
+llama stack run together
+```
+
+The default port is 5000 for `llama stack run` and you can specify a different port by adding `--port <your_port>` to the end of `llama stack run fireworks|together`.
+
+## Build and Run the iOS demo
+
+1. Double click `ios_calendar_assistant/iOSCalendarAssistant.xcodeproj` to open it in Xcode.
+
+2. Under the iOSCalendarAssistant project - Package Dependencies, click the + sign, then add `https://github.com/meta-llama/llama-stack-client-swift` at the top right and 0.1.0 in the Dependency Rule, then click Add Package.
+
+3. (Optional) Replace the `RemoteInference` url string in `ContentView.swift` below with the host IP and port of the remote Llama Stack distro  in Build and Run Own Llama Stack Distro:
+
+```
+private let agent = RemoteAgents(url: URL(string: "https://llama-stack.together.ai")!)
+```
+
+**Note:** In order for the app to access the remote URL, the app's `Info.plist` needs to have the entry `App Transport Security Settings` with `Allow Arbitrary Loads` set to YES.
+
+Also, to allow the app to add event to the Calendar app, the `Info.plist` needs to have an entry `Privacy - Calendars Usage Description` and when running the app for the first time, you need to accept the Calendar access request.
+
+4. Build the run the app on an iOS simulator or your device. First you may try a simple request:
+
+```
+Create a calendar event with a meeting title as Llama Stack update for 2-3pm February 19, 2025.
+```
+
+Then, a detailed meeting note:
+```
+Date: February 20, 2025
+Time: 10:00 AM - 11:00 AM
+Location: Zoom
+Attendees:
+Sarah (Team Lead)
+John (Marketing Manager)
+Emily (Product Designer)
+Mike (Developer)
+Jane (Operations Manager)
+
+Sarah: Good morning, everyone. Thanks for joining the meeting today. Let’s get started. Our main agenda is to review progress on the new product launch and address any blockers.
+John: Morning, Sarah. I can kick things off with the marketing update. The campaign assets are 80% ready. We’re working on finalizing the social media calendar and ad creatives.
+Sarah: Great progress, John. Do you foresee any risks to meeting the launch deadline?
+John: The only concern is securing approvals for ad copy. It’s taking longer than expected.
+Sarah: Understood. Let’s prioritize getting those approvals. Emily, can you ensure the design team supports that?
+Emily: Absolutely. I’ll follow up with the team today.
+Sarah: Perfect. Mike, how’s development coming along?
+Mike: We’re on track with the MVP build. There’s one issue with the payment gateway integration, but we expect to resolve it by the end of the week.
+Jane: Mike, will that delay testing?
+Mike: No, we’re scheduling other tests around it to stay on schedule.
+Sarah: Good. Jane, any updates from operations?
+Jane: Yes, logistics are sorted, and we’ve confirmed the warehouse availability. The only pending item is training customer support for the new product.
+Sarah: Let’s coordinate with the training team to expedite that. Anything else?
+Mike: Quick note—can we get feedback on the beta version by Friday?
+Sarah: Yes, let’s make that a priority. Anything else? No? Great. Thanks, everyone. Let’s meet again next week from 4-5pm on February 27, 2025 to review progress.
+```
+
+You'll see a summary, action items and a Calendar event created, made possible by Llama Stack's custom tool calling API support and Llama 3.1's tool calling capability.
+
+
+# iOSCalendarAssistantWithLocalInf
+
+iOSCalendarAssistantWithLocalInf is a demo app that uses Llama Stack Swift SDK's local inference and agent APIs and ExecuTorch to run local inference on device.
+
+1. On a Mac terminal, in your top level directory, run commands:
+```
+git clone https://github.com/meta-llama/llama-stack-apps
+git clone https://github.com/meta-llama/llama-stack-client-swift
+cd llama-stack-client-swift
+git submodule update --init --recursive
+```
+
+2. Open `llama-stack-apps/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj` in Xcode.
+
+3. In the `iOSCalendarAssistantWithLocalInf` project panel, remove `LocalInferenceImpl.xcodeproj` and drag and drop `LocalInferenceImpl.xcodeproj` from `llama-stack-client-swift/local_inference` into the project - in the "Choose options for adding these files" dialog, select "Reference files in place" for Action.
+
+4. Prepare a Llama model file named `llama3_2_spinquant_oct23.pte` by following the steps [here](https://github.com/pytorch/executorch/blob/main/examples/models/llama/README.md#step-2-prepare-model) - you'll also download the `tokenizer.model` file there. Then remove the two missing files from the the project `iOSCalendarAssistantWithLocalInf`, and drag and drop both files to the project, also selecting "Reference files in place" for Action.
+
+5. Build and run the app on an iOS simulator or a real device.
+
+**Note** If you see a build error about cmake not found, you can install cmake by following the instruction [here](https://github.com/pytorch/executorch/blob/main/examples/demo-apps/apple_ios/LLaMA/docs/delegates/xnnpack_README.md#1-install-cmake).

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant.xcodeproj/project.pbxproj
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant.xcodeproj/project.pbxproj
@@ -1,0 +1,379 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		5C200C1B2CA3CC3C0026EA40 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5C200C112CA3CC3C0026EA40 /* Preview Assets.xcassets */; };
+		5C200C1C2CA3CC3C0026EA40 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5C200C132CA3CC3C0026EA40 /* Assets.xcassets */; };
+		5C200C1D2CA3CC3C0026EA40 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C200C142CA3CC3C0026EA40 /* ContentView.swift */; };
+		5C200C1E2CA3CC3C0026EA40 /* EventEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C200C152CA3CC3C0026EA40 /* EventEditView.swift */; };
+		5C200C1F2CA3CC3C0026EA40 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C200C162CA3CC3C0026EA40 /* Message.swift */; };
+		5C200C202CA3CC3C0026EA40 /* MessageListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C200C172CA3CC3C0026EA40 /* MessageListView.swift */; };
+		5C200C212CA3CC3C0026EA40 /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C200C182CA3CC3C0026EA40 /* MessageView.swift */; };
+		5C200C222CA3CC3C0026EA40 /* iOSCalendarAssistantApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C200C192CA3CC3C0026EA40 /* iOSCalendarAssistantApp.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		265029812D46B28700D06225 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5C200C112CA3CC3C0026EA40 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		5C200C132CA3CC3C0026EA40 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5C200C142CA3CC3C0026EA40 /* ContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		5C200C152CA3CC3C0026EA40 /* EventEditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventEditView.swift; sourceTree = "<group>"; };
+		5C200C162CA3CC3C0026EA40 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		5C200C172CA3CC3C0026EA40 /* MessageListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageListView.swift; sourceTree = "<group>"; };
+		5C200C182CA3CC3C0026EA40 /* MessageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageView.swift; sourceTree = "<group>"; };
+		5C200C192CA3CC3C0026EA40 /* iOSCalendarAssistantApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iOSCalendarAssistantApp.swift; sourceTree = "<group>"; };
+		5CADB0012CA1345100942A87 /* iOSCalendarAssistant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSCalendarAssistant.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5CADAFFE2CA1345100942A87 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		5C200C122CA3CC3C0026EA40 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				5C200C112CA3CC3C0026EA40 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		5C200C1A2CA3CC3C0026EA40 /* iOSCalendarAssistant */ = {
+			isa = PBXGroup;
+			children = (
+				265029812D46B28700D06225 /* Info.plist */,
+				5C200C122CA3CC3C0026EA40 /* Preview Content */,
+				5C200C132CA3CC3C0026EA40 /* Assets.xcassets */,
+				5C200C142CA3CC3C0026EA40 /* ContentView.swift */,
+				5C200C152CA3CC3C0026EA40 /* EventEditView.swift */,
+				5C200C162CA3CC3C0026EA40 /* Message.swift */,
+				5C200C172CA3CC3C0026EA40 /* MessageListView.swift */,
+				5C200C182CA3CC3C0026EA40 /* MessageView.swift */,
+				5C200C192CA3CC3C0026EA40 /* iOSCalendarAssistantApp.swift */,
+			);
+			path = iOSCalendarAssistant;
+			sourceTree = "<group>";
+		};
+		5CADAFF82CA1345100942A87 = {
+			isa = PBXGroup;
+			children = (
+				5C200C1A2CA3CC3C0026EA40 /* iOSCalendarAssistant */,
+				CFF364122D45D2AF00D93284 /* Frameworks */,
+				5CADB0022CA1345100942A87 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		5CADB0022CA1345100942A87 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5CADB0012CA1345100942A87 /* iOSCalendarAssistant.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CFF364122D45D2AF00D93284 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		5CADB0002CA1345100942A87 /* iOSCalendarAssistant */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5CADB0252CA1345300942A87 /* Build configuration list for PBXNativeTarget "iOSCalendarAssistant" */;
+			buildPhases = (
+				5CADAFFD2CA1345100942A87 /* Sources */,
+				5CADAFFE2CA1345100942A87 /* Frameworks */,
+				5CADAFFF2CA1345100942A87 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iOSCalendarAssistant;
+			packageProductDependencies = (
+			);
+			productName = StackSummary;
+			productReference = 5CADB0012CA1345100942A87 /* iOSCalendarAssistant.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5CADAFF92CA1345100942A87 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					5CADB0002CA1345100942A87 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = 5CADAFFC2CA1345100942A87 /* Build configuration list for PBXProject "iOSCalendarAssistant" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 5CADAFF82CA1345100942A87;
+			packageReferences = (
+			);
+			productRefGroup = 5CADB0022CA1345100942A87 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5CADB0002CA1345100942A87 /* iOSCalendarAssistant */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5CADAFFF2CA1345100942A87 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C200C1B2CA3CC3C0026EA40 /* Preview Assets.xcassets in Resources */,
+				5C200C1C2CA3CC3C0026EA40 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5CADAFFD2CA1345100942A87 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C200C1E2CA3CC3C0026EA40 /* EventEditView.swift in Sources */,
+				5C200C1F2CA3CC3C0026EA40 /* Message.swift in Sources */,
+				5C200C1D2CA3CC3C0026EA40 /* ContentView.swift in Sources */,
+				5C200C222CA3CC3C0026EA40 /* iOSCalendarAssistantApp.swift in Sources */,
+				5C200C212CA3CC3C0026EA40 /* MessageView.swift in Sources */,
+				5C200C202CA3CC3C0026EA40 /* MessageListView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		5CADB0232CA1345300942A87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		5CADB0242CA1345300942A87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5CADB0262CA1345300942A87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"iOSCalendarAssistant/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iOSCalendarAssistant/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = meta.StackSummary;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		5CADB0272CA1345300942A87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"iOSCalendarAssistant/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iOSCalendarAssistant/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = meta.StackSummary;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5CADAFFC2CA1345100942A87 /* Build configuration list for PBXProject "iOSCalendarAssistant" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5CADB0232CA1345300942A87 /* Debug */,
+				5CADB0242CA1345300942A87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5CADB0252CA1345300942A87 /* Build configuration list for PBXNativeTarget "iOSCalendarAssistant" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5CADB0262CA1345300942A87 /* Debug */,
+				5CADB0272CA1345300942A87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5CADAFF92CA1345100942A87 /* Project object */;
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/Assets.xcassets/Contents.json
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/ContentView.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/ContentView.swift
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+import LlamaStackClient
+
+import EventKit
+import EventKitUI
+
+struct ContentView: View {
+  @State private var prompt = ""
+  @State private var messages: [Message] = []
+  @State private var isGenerating = false
+  private let runnerQueue = DispatchQueue(label: "org.llamastack.stacksummary")
+
+  @State var eventStore = EKEventStore()
+  @State private var showAlert = false
+  @State private var alertMessage = ""
+  
+  // replace the URL string if you build and run your own Llama Stack distro as shown in https://github.com/meta-llama/llama-stack-apps/tree/main/examples/ios_quick_demo#optional-build-and-run-own-llama-stack-distro
+  private let agent = RemoteAgents(url: URL(string: "https://llama-stack.together.ai")!)
+  
+  @State var agentId = ""
+  @State var agenticSystemSessionId = ""
+
+  @State private var actionItems = ""
+
+  private var placeholder: String {
+    "Ask Llama to summarize..."
+  }
+
+  private var title: String {
+    "StackSummary"
+  }
+
+  private var isInputEnabled: Bool { return !isGenerating }
+
+  var body: some View {
+    NavigationView {
+      VStack {
+        MessageListView(messages: $messages)
+          .gesture(
+            DragGesture().onChanged { value in
+              if value.translation.height > 10 {
+                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+              }
+            }
+          )
+        HStack {
+          TextField(placeholder, text: $prompt, axis: .vertical)
+            .padding(8)
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(20)
+            .lineLimit(1...10)
+            .overlay(
+              RoundedRectangle(cornerRadius: 20)
+                .stroke(isInputEnabled ? Color.blue : Color.gray, lineWidth: 1)
+            )
+            .disabled(!isInputEnabled)
+
+          Button(action: generate) {
+            Image(systemName: "arrowshape.up.circle.fill")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(height: 28)
+          }
+          .disabled(isGenerating || (!isInputEnabled || prompt.isEmpty))
+        }
+        .padding([.leading, .trailing, .bottom], 10)
+      }
+      .alert(isPresented: $showAlert) {
+          Alert(title: Text("Calendar Event"), message: Text(alertMessage), dismissButton: .default(Text("OK")))
+      }
+    }
+  }
+
+  func triggerAddEventToCalendar(title: String, startDate: Date, endDate: Date) {
+    eventStore.requestAccess(to: .event) { [self] granted, error in
+      DispatchQueue.main.async {
+        if granted {
+          let event = EKEvent(eventStore: eventStore)
+          event.title = title
+          event.startDate = startDate
+          event.endDate = endDate
+          event.calendar = eventStore.defaultCalendarForNewEvents
+          event.notes = self.actionItems
+          
+          do {
+            try eventStore.save(event, span: .thisEvent, commit: true)
+            alertMessage = "Event \(title) saved successfully to calendar"
+            showAlert = true
+          } catch let error {
+            alertMessage = "Failed to save event: \(error.localizedDescription)"
+            showAlert = true
+          }
+        } else {
+          print("Calendar access denied")
+          alertMessage = "Calendar access denied"
+          showAlert = true
+        }
+      }
+    }
+  }
+
+  func summarizeConversation(prompt: String) async {
+    do {
+        let request = Components.Schemas.CreateAgentTurnRequest(
+        messages: [
+          .UserMessage(Components.Schemas.UserMessage(
+            role: .user,
+            content: .case1("Summarize the following conversation in 1-2 sentences:\n\n \(prompt)")
+          ))
+        ],
+        stream: true
+      )
+
+      for try await chunk in try await self.agent.createTurn(agent_id: self.agentId, session_id: self.agenticSystemSessionId, request: request) {
+        let payload = chunk.event.payload
+        switch (payload) {
+        case .step_start:
+          break
+        case .step_progress(let step):
+            DispatchQueue.main.async(execute: DispatchWorkItem {
+              withAnimation {
+                var message = messages.removeLast()
+                if case .text(let delta) = step.delta {
+                  message.text += "\(delta.text)"
+                }
+                
+                message.tokenCount += 2
+                message.dateUpdated = Date()
+                messages.append(message)
+                print(message.text)
+              }
+            })
+            break
+        case .step_complete(_):
+          break
+        case .turn_start(_):
+          break
+        case .turn_complete(_):
+          break
+        case .turn_awaiting_input(_):
+          break
+        }
+
+      }
+    } catch {
+      print("Summarization failed: \(error)")
+    }
+  }
+
+  func actionItems(prompt: String) async throws {
+    let request = Components.Schemas.CreateAgentTurnRequest(
+      messages: [
+        .UserMessage(Components.Schemas.UserMessage(
+          role: .user,
+          content: .case1("List out any action items based on this text:\n\n \(prompt)")
+        ))
+      ],
+      stream: true
+    )
+
+    for try await chunk in try await self.agent.createTurn(agent_id: self.agentId, session_id: self.agenticSystemSessionId, request: request) {
+      let payload = chunk.event.payload
+      switch (payload) {
+      case .step_start(_):
+        break
+      case .step_progress(let step):
+          DispatchQueue.main.async(execute: DispatchWorkItem {
+            withAnimation {
+              var message = messages.removeLast()
+              
+              if case .text(let delta) = step.delta {
+                message.text += "\(delta.text)"
+                self.actionItems += "\(delta.text)"
+              }
+              message.tokenCount += 2
+              message.dateUpdated = Date()
+              messages.append(message)
+            }
+          })
+      case .step_complete(_):
+        break
+      case .turn_start(_):
+        break
+      case .turn_complete(_):
+        break
+      case .turn_awaiting_input(_):
+        break
+      }
+    }
+  }
+
+  func callTools(prompt: String) async throws {
+    
+    let request = Components.Schemas.CreateAgentTurnRequest(
+      messages: [
+        .UserMessage(Components.Schemas.UserMessage(
+          role: .user,
+          content: .case1("Call functions as needed to handle any actions in the following text:\n\n" + prompt)
+        ))
+      ],
+      stream: true
+    )
+
+    for try await chunk in try await self.agent.createTurn(agent_id: self.agentId, session_id: self.agenticSystemSessionId, request: request) {
+      
+      let payload = chunk.event.payload
+      switch (payload) {
+      case .step_start(_):
+        break
+        
+      case .step_progress(let step):
+          switch (step.delta) {
+          case .tool_call(let call):
+            if call.parse_status == .succeeded {
+              switch (call.tool_call) {
+              case .ToolCall(let toolCall):
+                  var args: [String : String] = [:]
+                  for (arg_name, arg) in toolCall.arguments.additionalProperties {
+                    switch (arg) {
+                    case .case1(let s):
+                      args[arg_name] = s
+                    case .case2(_), .case3(_), .case4(_), .case5(_), .case6(_):
+                      break
+                    }
+                  }
+  
+                  let formatter = DateFormatter()
+                  formatter.dateFormat = "yyyy-MM-dd HH:mm"
+                  formatter.timeZone = TimeZone.current
+                  formatter.locale = Locale.current
+                  self.triggerAddEventToCalendar(
+                    title: args["event_name"]!,
+                    startDate: formatter.date(from: args["start"]!) ?? Date(),
+                    endDate: formatter.date(from: args["end"]!) ?? Date()
+                  )
+              case .case1(_):
+                break
+              }
+            }
+          case .text(let text):
+            break
+          case .image(_):
+            break
+          }
+        break
+      case .step_complete(_):
+        break
+      case .turn_start(_):
+        break
+      case .turn_complete(_):
+        break
+      case .turn_awaiting_input(_):
+        break
+      }
+    }
+  }
+
+  private func generate() {
+    guard !prompt.isEmpty else { return }
+    isGenerating = true
+
+    
+    let text = prompt
+    prompt = ""
+    hideKeyboard()
+
+    let workItem = DispatchWorkItem {
+      defer {
+        DispatchQueue.main.async {
+          isGenerating = false
+        }
+      }
+
+      Task {
+        messages.append(Message(text: text))
+        messages.append(Message(type: .summary))
+
+        do {
+          let createSystemResponse = try await self.agent.create(
+            request: Components.Schemas.CreateAgentRequest(
+              agent_config: Components.Schemas.AgentConfig(
+                client_tools: [ CustomTools.getCreateEventToolForAgent() ],
+                max_infer_iters: 1,
+                model: "meta-llama/Llama-3.1-8B-Instruct",
+                instructions: "You are a helpful assistant",
+                enable_session_persistence: false
+              )
+            )
+          )
+          self.agentId = createSystemResponse.agent_id
+
+          let createSessionResponse = try await self.agent.createSession(agent_id: self.agentId,
+            request: Components.Schemas.CreateAgentSessionRequest(session_name: "llama-assistant")
+          )
+          self.agenticSystemSessionId = createSessionResponse.session_id
+
+          await summarizeConversation(prompt: text)
+
+          messages.append(Message(type: .actionItems))
+          try await actionItems(prompt: text)
+
+          try await callTools(prompt: text)
+          
+        } catch {
+          print("Error: \(error)")
+        }
+      }
+    }
+    
+    runnerQueue.async(execute: workItem)
+  }
+}
+
+extension View {
+  func hideKeyboard() {
+    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/EventEditView.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/EventEditView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import EventKit
+import EventKitUI
+
+struct EventEditView: UIViewControllerRepresentable {
+  @Binding var isPresented: Bool
+  let eventStore: EKEventStore
+  let event: EKEvent
+
+  func makeUIViewController(context: Context) -> EKEventEditViewController {
+    let controller = EKEventEditViewController()
+    controller.eventStore = eventStore
+    controller.event = event
+    controller.editViewDelegate = context.coordinator
+    return controller
+  }
+
+  func updateUIViewController(_ uiViewController: EKEventEditViewController, context: Context) {}
+
+  func makeCoordinator() -> Coordinator {
+    return Coordinator(isPresented: $isPresented)
+  }
+
+  class Coordinator: NSObject, EKEventEditViewDelegate {
+    @Binding var isPresented: Bool
+
+    init(isPresented: Binding<Bool>) {
+      _isPresented = isPresented
+    }
+
+    func eventEditViewController(_ controller: EKEventEditViewController, didCompleteWith action: EKEventEditViewAction) {
+      isPresented = false
+    }
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/Info.plist
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSCalendarsUsageDescription</key>
+	<string>We need access to your calendar to schedule events.</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/Message.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/Message.swift
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import UIKit
+
+enum MessageType {
+  case prompted
+  case summary
+  case actionItems
+  case llavagenerated
+  case info
+}
+
+struct Message: Identifiable, Equatable {
+  let id = UUID()
+  let dateCreated = Date()
+  var dateUpdated = Date()
+  var type: MessageType = .prompted
+  var text = ""
+  var tokenCount = 0
+  var image: UIImage?
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/MessageListView.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/MessageListView.swift
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+struct MessageListView: View {
+  @Binding var messages: [Message]
+  @State private var showScrollToBottomButton = false
+  @State private var userHasScrolled = false
+  @State private var keyboardHeight: CGFloat = 0
+
+  var body: some View {
+    ScrollViewReader { value in
+      ScrollView {
+        VStack {
+          ForEach(messages) { message in
+            MessageView(message: message)
+              .padding([.leading, .trailing], 20)
+          }
+          GeometryReader { geometry -> Color in
+            DispatchQueue.main.async {
+              let maxY = geometry.frame(in: .global).maxY
+              let screenHeight = UIScreen.main.bounds.height - keyboardHeight
+              let isBeyondBounds = maxY > screenHeight - 50
+              if showScrollToBottomButton != isBeyondBounds {
+                showScrollToBottomButton = isBeyondBounds
+                userHasScrolled = isBeyondBounds
+              }
+            }
+            return Color.clear
+          }
+          .frame(height: 0)
+        }
+      }
+      .onChange(of: messages) {
+        if !userHasScrolled, let lastMessageId = messages.last?.id {
+          withAnimation {
+            value.scrollTo(lastMessageId, anchor: .bottom)
+          }
+        }
+      }
+      .overlay(
+        Group {
+          if false {
+            Button(action: {
+              withAnimation {
+                if let lastMessageId = messages.last?.id {
+                  value.scrollTo(lastMessageId, anchor: .bottom)
+                }
+                userHasScrolled = false
+              }
+            }) {
+              ZStack {
+                Circle()
+                  .fill(Color(UIColor.secondarySystemBackground).opacity(0.9))
+                  .frame(height: 28)
+                Image(systemName: "arrow.down.circle")
+                  .resizable()
+                  .aspectRatio(contentMode: .fit)
+                  .frame(height: 28)
+              }
+            }
+            .transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.2)))
+          }
+        },
+        alignment: .bottom
+      )
+    }
+    .onAppear {
+      NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { notification in
+        let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect ?? .zero
+        keyboardHeight = keyboardFrame.height - 40
+      }
+      NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
+        keyboardHeight = 0
+      }
+    }
+    .onDisappear {
+      NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+      NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/MessageView.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/MessageView.swift
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+struct MessageView: View {
+  let message: Message
+
+  var body: some View {
+    VStack(alignment: .center) {
+      if message.type == .info {
+        Text(message.text)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .padding([.leading, .trailing], 10)
+      } else {
+        VStack(alignment: message.type == .summary || message.type == .actionItems || message.type == .llavagenerated ? .leading : .trailing) {
+          if message.type == .summary || message.type == .actionItems || message.type == .llavagenerated || message.type == .prompted {
+            Text(message.type == .summary ? "Summary" : (message.type == .actionItems ? "Action Items" : "Prompt"))
+              .font(.caption)
+              .foregroundColor(.secondary)
+              .padding(message.type == .summary || message.type == .actionItems ? .trailing : .leading, 20)
+          }
+          HStack {
+            if message.type != .summary && message.type != .actionItems && message.type != .llavagenerated { Spacer() }
+            if message.text.isEmpty {
+              if let img = message.image {
+                Image(uiImage: img)
+                  .resizable()
+                  .scaledToFit()
+                  .frame(maxWidth: 200, maxHeight: 200)
+                  .padding()
+                  .background(Color.gray.opacity(0.2))
+                  .cornerRadius(8)
+                  .padding(.vertical, 2)
+              } else {
+                ProgressView()
+                  .progressViewStyle(CircularProgressViewStyle())
+              }
+            } else {
+              Text(message.text)
+                .padding(10)
+                .foregroundColor(message.type == .summary || message.type == .actionItems ? .primary : .white)
+                .background(message.type == .summary || message.type == .actionItems ? Color(UIColor.secondarySystemBackground) : Color.blue)
+                .cornerRadius(20)
+                .contextMenu {
+                  Button(action: {
+                    UIPasteboard.general.string = message.text
+                  }) {
+                    Text("Copy")
+                    Image(systemName: "doc.on.doc")
+                  }
+                }
+            }
+            if message.type == .summary || message.type == .actionItems { Spacer() }
+          }
+          let elapsedTime = message.dateUpdated.timeIntervalSince(message.dateCreated)
+        }.padding([.leading, .trailing], message.type == .info ? 0 : 10)
+      }
+    }
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/iOSCalendarAssistantApp.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/iOSCalendarAssistantApp.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+@main
+struct iOSCalendarAssistantApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.pbxproj
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.pbxproj
@@ -1,0 +1,434 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		5C9590A42CD545F20092F7F0 /* tokenizer.model in Resources */ = {isa = PBXBuildFile; fileRef = 5C9590A22CD545F20092F7F0 /* tokenizer.model */; };
+		5C9590A62CD546230092F7F0 /* llama3_2_spinquant_oct23.pte in Resources */ = {isa = PBXBuildFile; fileRef = 5C9590A52CD546230092F7F0 /* llama3_2_spinquant_oct23.pte */; };
+		5C9644D32CCAC6A100B80462 /* LLaMARunner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */; };
+		5C9644D42CCAC6DE00B80462 /* LLaMARunner.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5CADC7022CA45670007662D2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5CADC6F92CA45670007662D2 /* Assets.xcassets */; };
+		5CADC7032CA45670007662D2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FA2CA45670007662D2 /* ContentView.swift */; };
+		5CADC7042CA45670007662D2 /* EventEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FB2CA45670007662D2 /* EventEditView.swift */; };
+		5CADC7052CA45670007662D2 /* iOSCalendarAssistantApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FC2CA45670007662D2 /* iOSCalendarAssistantApp.swift */; };
+		5CADC7062CA45670007662D2 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FD2CA45670007662D2 /* Message.swift */; };
+		5CADC7072CA45670007662D2 /* MessageListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FE2CA45670007662D2 /* MessageListView.swift */; };
+		5CADC7082CA45670007662D2 /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FF2CA45670007662D2 /* MessageView.swift */; };
+		5CADC71C2CA4741B007662D2 /* LocalInferenceImpl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */; };
+		5CADC71D2CA4741B007662D2 /* LocalInferenceImpl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BA2967392D814ED4006AB504 /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = BA2967382D814ED4006AB504 /* LlamaStackClient */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		5CADC7172CA467C4007662D2 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				5C9644D42CCAC6DE00B80462 /* LLaMARunner.framework in Embed Frameworks */,
+				5CADC71D2CA4741B007662D2 /* LocalInferenceImpl.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		5C5E31D32CA48A5800A0784C /* LocalInferenceImpl.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LocalInferenceImpl.xcodeproj; path = "iOSCalendarAssistantWithLocalInf/llama-stack/llama_stack/providers/impls/ios/inference/LocalInferenceImpl.xcodeproj"; sourceTree = "<group>"; };
+		5C9590A22CD545F20092F7F0 /* tokenizer.model */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = tokenizer.model; path = ../../../tokenizer.model; sourceTree = "<group>"; };
+		5C9590A52CD546230092F7F0 /* llama3_2_spinquant_oct23.pte */ = {isa = PBXFileReference; lastKnownFileType = file; path = llama3_2_spinquant_oct23.pte; sourceTree = "<group>"; };
+		5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LLaMARunner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CADB0012CA1345100942A87 /* iOSCalendarAssistantWithLocalInf.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSCalendarAssistantWithLocalInf.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CADC6F72CA45670007662D2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		5CADC6F92CA45670007662D2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5CADC6FA2CA45670007662D2 /* ContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		5CADC6FB2CA45670007662D2 /* EventEditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventEditView.swift; sourceTree = "<group>"; };
+		5CADC6FC2CA45670007662D2 /* iOSCalendarAssistantApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iOSCalendarAssistantApp.swift; sourceTree = "<group>"; };
+		5CADC6FD2CA45670007662D2 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		5CADC6FE2CA45670007662D2 /* MessageListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageListView.swift; sourceTree = "<group>"; };
+		5CADC6FF2CA45670007662D2 /* MessageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageView.swift; sourceTree = "<group>"; };
+		5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LocalInferenceImpl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5CADAFFE2CA1345100942A87 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C9644D32CCAC6A100B80462 /* LLaMARunner.framework in Frameworks */,
+				BA2967392D814ED4006AB504 /* LlamaStackClient in Frameworks */,
+				5CADC71C2CA4741B007662D2 /* LocalInferenceImpl.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		5CADAFF82CA1345100942A87 = {
+			isa = PBXGroup;
+			children = (
+				5C9590A22CD545F20092F7F0 /* tokenizer.model */,
+				5C9590A52CD546230092F7F0 /* llama3_2_spinquant_oct23.pte */,
+				5C5E31D32CA48A5800A0784C /* LocalInferenceImpl.xcodeproj */,
+				5CADC7002CA45670007662D2 /* iOSCalendarAssistantWithLocalInf */,
+				5CADB0022CA1345100942A87 /* Products */,
+				5CADC7142CA467C4007662D2 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		5CADB0022CA1345100942A87 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5CADB0012CA1345100942A87 /* iOSCalendarAssistantWithLocalInf.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5CADC6F82CA45670007662D2 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				5CADC6F72CA45670007662D2 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		5CADC7002CA45670007662D2 /* iOSCalendarAssistantWithLocalInf */ = {
+			isa = PBXGroup;
+			children = (
+				5CADC6F82CA45670007662D2 /* Preview Content */,
+				5CADC6F92CA45670007662D2 /* Assets.xcassets */,
+				5CADC6FA2CA45670007662D2 /* ContentView.swift */,
+				5CADC6FB2CA45670007662D2 /* EventEditView.swift */,
+				5CADC6FC2CA45670007662D2 /* iOSCalendarAssistantApp.swift */,
+				5CADC6FD2CA45670007662D2 /* Message.swift */,
+				5CADC6FE2CA45670007662D2 /* MessageListView.swift */,
+				5CADC6FF2CA45670007662D2 /* MessageView.swift */,
+			);
+			path = iOSCalendarAssistantWithLocalInf;
+			sourceTree = "<group>";
+		};
+		5CADC7142CA467C4007662D2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */,
+				5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		5CADB0002CA1345100942A87 /* iOSCalendarAssistantWithLocalInf */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5CADB0252CA1345300942A87 /* Build configuration list for PBXNativeTarget "iOSCalendarAssistantWithLocalInf" */;
+			buildPhases = (
+				5CADAFFD2CA1345100942A87 /* Sources */,
+				5CADAFFE2CA1345100942A87 /* Frameworks */,
+				5CADAFFF2CA1345100942A87 /* Resources */,
+				5CADC7172CA467C4007662D2 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iOSCalendarAssistantWithLocalInf;
+			packageProductDependencies = (
+				BA2967382D814ED4006AB504 /* LlamaStackClient */,
+			);
+			productName = StackSummary;
+			productReference = 5CADB0012CA1345100942A87 /* iOSCalendarAssistantWithLocalInf.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5CADAFF92CA1345100942A87 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					5CADB0002CA1345100942A87 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = 5CADAFFC2CA1345100942A87 /* Build configuration list for PBXProject "iOSCalendarAssistantWithLocalInf" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 5CADAFF82CA1345100942A87;
+			packageReferences = (
+				BA2967372D814ED4006AB504 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */,
+			);
+			productRefGroup = 5CADB0022CA1345100942A87 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5CADB0002CA1345100942A87 /* iOSCalendarAssistantWithLocalInf */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5CADAFFF2CA1345100942A87 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5CADC7022CA45670007662D2 /* Assets.xcassets in Resources */,
+				5C9590A42CD545F20092F7F0 /* tokenizer.model in Resources */,
+				5C9590A62CD546230092F7F0 /* llama3_2_spinquant_oct23.pte in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5CADAFFD2CA1345100942A87 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5CADC7082CA45670007662D2 /* MessageView.swift in Sources */,
+				5CADC7052CA45670007662D2 /* iOSCalendarAssistantApp.swift in Sources */,
+				5CADC7062CA45670007662D2 /* Message.swift in Sources */,
+				5CADC7032CA45670007662D2 /* ContentView.swift in Sources */,
+				5CADC7072CA45670007662D2 /* MessageListView.swift in Sources */,
+				5CADC7042CA45670007662D2 /* EventEditView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		5CADB0232CA1345300942A87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		5CADB0242CA1345300942A87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5CADB0262CA1345300942A87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"iOSCalendarAssistant/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = "-lstdc++";
+				PRODUCT_BUNDLE_IDENTIFIER = meta.StackSummary;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		5CADB0272CA1345300942A87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"iOSCalendarAssistant/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = "-lstdc++";
+				PRODUCT_BUNDLE_IDENTIFIER = meta.StackSummary;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5CADAFFC2CA1345100942A87 /* Build configuration list for PBXProject "iOSCalendarAssistantWithLocalInf" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5CADB0232CA1345300942A87 /* Debug */,
+				5CADB0242CA1345300942A87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5CADB0252CA1345300942A87 /* Build configuration list for PBXNativeTarget "iOSCalendarAssistantWithLocalInf" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5CADB0262CA1345300942A87 /* Debug */,
+				5CADB0272CA1345300942A87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BA2967372D814ED4006AB504 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/meta-llama/llama-stack-client-swift";
+			requirement = {
+				branch = "latest-release";
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BA2967382D814ED4006AB504 /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BA2967372D814ED4006AB504 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */;
+			productName = LlamaStackClient;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 5CADAFF92CA1345100942A87 /* Project object */;
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,105 @@
+{
+  "originHash" : "df038bcc9f4c58946ce49e72295f54d7068f7de8d60780a55423d96d21e68a16",
+  "pins" : [
+    {
+      "identity" : "llama-stack-client-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/meta-llama/llama-stack-client-swift",
+      "state" : {
+        "branch" : "latest-release",
+        "revision" : "fafb0cf96b1b51098e09dca9547a4680da274d25"
+      }
+    },
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit",
+      "state" : {
+        "revision" : "90c137c3dfde4e31204ffccc51a0a17a959efde7",
+        "version" : "3.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "ef18d829e8b92d731ad27bb81583edd2094d1ce3",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-openapi-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-generator",
+      "state" : {
+        "revision" : "84b693f9d0559dc488e691edb4837bafbce2aaea",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime.git",
+      "state" : {
+        "revision" : "23146bc8710ac5e57abb693113f02dc274cf39b6",
+        "version" : "1.8.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-urlsession",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-urlsession.git",
+      "state" : {
+        "revision" : "9bf4c712ad7989d6a91dbe68748b8829a50837e4",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "b4b8042411dc7bbb696300a34a4bf3ba1b7ad19b",
+        "version" : "5.3.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/xcshareddata/xcschemes/iOSCalendarAssistantWithLocalInf.xcscheme
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/xcshareddata/xcschemes/iOSCalendarAssistantWithLocalInf.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5CADB0002CA1345100942A87"
+               BuildableName = "iOSCalendarAssistantWithLocalInf.app"
+               BlueprintName = "iOSCalendarAssistantWithLocalInf"
+               ReferencedContainer = "container:iOSCalendarAssistantWithLocalInf.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CADB0002CA1345100942A87"
+            BuildableName = "iOSCalendarAssistantWithLocalInf.app"
+            BlueprintName = "iOSCalendarAssistantWithLocalInf"
+            ReferencedContainer = "container:iOSCalendarAssistantWithLocalInf.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CADB0002CA1345100942A87"
+            BuildableName = "iOSCalendarAssistantWithLocalInf.app"
+            BlueprintName = "iOSCalendarAssistantWithLocalInf"
+            ReferencedContainer = "container:iOSCalendarAssistantWithLocalInf.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/Assets.xcassets/Contents.json
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/ContentView.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/ContentView.swift
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+import LlamaStackClient
+import LocalInferenceImpl
+
+import EventKit
+import EventKitUI
+
+struct ContentView: View {
+  @State private var prompt = ""
+  @State private var messages: [Message] = []
+  @State private var isGenerating = false
+  private let runnerQueue = DispatchQueue(label: "org.llamastack.stacksummary")
+
+  @State var eventStore = EKEventStore()
+  @State var presetEvent: EKEvent?
+
+  @State var isShowingEventModal = false
+
+  private let inference: LocalInference
+  private let localAgents: LocalAgents
+  private let remoteAgents: RemoteAgents
+  @State private var isUsingLocalAgents = true
+
+  @State var agentId = ""
+  @State var agenticSystemSessionId = ""
+
+  @State private var actionItems = ""
+
+  public init () {
+    self.inference = LocalInference(queue: runnerQueue)
+    self.localAgents = LocalAgents(inference: self.inference)
+    
+    // replace the URL string if you build and run your own Llama Stack distro as shown in https://github.com/meta-llama/llama-stack-apps/tree/main/examples/ios_calendar_assistant#optional-build-and-run-own-llama-stack-distro
+    self.remoteAgents = RemoteAgents(url: URL(string: "https://llama-stack.together.ai")!)
+  }
+
+  var agents: Agents {
+    get { isUsingLocalAgents ? self.localAgents : self.remoteAgents }
+  }
+
+  private var placeholder: String {
+    "Ask Llama to summarize..."
+  }
+
+  private var title: String {
+    "StackSummary"
+  }
+
+  private var isInputEnabled: Bool { return !isGenerating }
+
+  var body: some View {
+    NavigationView {
+      VStack {
+        Picker("Agent Type", selection: $isUsingLocalAgents) {
+          Text("Local").tag(true)
+          Text("Remote").tag(false)
+        }
+        .pickerStyle(.segmented)
+        .padding()
+        MessageListView(messages: $messages)
+                  .gesture(
+                    DragGesture().onChanged { value in
+                      if value.translation.height > 10 {
+                        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                      }
+                    }
+                  )
+        Spacer()
+
+        HStack {
+          TextField(placeholder, text: $prompt, axis: .vertical)
+            .padding(8)
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(20)
+            .lineLimit(1...10)
+            .overlay(
+              RoundedRectangle(cornerRadius: 20)
+                .stroke(isInputEnabled ? Color.blue : Color.gray, lineWidth: 1)
+            )
+            .disabled(!isInputEnabled)
+
+          Button(action: generate) {
+            Image(systemName: "arrowshape.up.circle.fill")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(height: 28)
+          }
+          .disabled(isGenerating || (!isInputEnabled || prompt.isEmpty))
+        }
+        .padding([.leading, .trailing, .bottom], 10)
+      }
+    }
+    .navigationViewStyle(StackNavigationViewStyle())
+    .sheet(isPresented:  Binding(
+      get: { self.presetEvent != nil },
+      set: { if !$0 { self.presetEvent = nil } }
+    )) {
+      if let event = presetEvent {
+        EventEditView(isPresented: $isShowingEventModal,
+                      eventStore: self.eventStore,
+                      event: event)
+      }
+    }
+  }
+
+  func triggerAddEventToCalendar(title: String, startDate: Date, endDate: Date) {
+    eventStore.requestAccess(to: .event) { [self] granted, error in
+      if granted {
+        let event = EKEvent(eventStore: eventStore)
+        event.title = title
+        event.startDate = startDate
+        event.endDate = endDate
+        event.calendar = eventStore.defaultCalendarForNewEvents
+        event.notes = self.actionItems
+        self.presetEvent = event
+      } else {
+        print("Calendar access denied")
+      }
+    }
+  }
+
+  func summarizeConversation(prompt: String) async {
+    do {
+      let request = Components.Schemas.CreateAgentTurnRequest(
+        messages: [
+          .UserMessage(Components.Schemas.UserMessage(
+            role: .user,
+            content: .case1("Summarize the following conversation in 1-2 sentences:\n\n \(prompt)")
+          ))
+        ],
+        stream: true
+      )
+
+      for try await chunk in try await self.agents.createTurn(agent_id: self.agentId, session_id: self.agenticSystemSessionId, request: request) {
+        let payload = chunk.event.payload
+        switch (payload) {
+        case .step_start(_):
+          break
+        case .step_progress(let step):
+          if (step.delta != nil) {
+            DispatchQueue.main.async {
+              withAnimation {
+                var message = messages.removeLast()
+                if case .text(let delta) = step.delta {
+                  message.text += "\(delta.text)"
+                }
+                message.tokenCount += 2
+                message.dateUpdated = Date()
+                messages.append(message)
+              }
+            }
+          }
+        case .step_complete(_):
+          break
+        case .turn_start(_):
+          break
+        case .turn_complete(_):
+          break
+        case .turn_awaiting_input(_):
+          break
+        }
+
+      }
+    } catch {
+      print("Summarization failed: \(error)")
+    }
+  }
+
+  func actionItems(prompt: String) async throws {
+    let request = Components.Schemas.CreateAgentTurnRequest(
+      messages: [
+        .UserMessage(Components.Schemas.UserMessage(
+          role: .user,
+          content: .case1("List out any action items based on this text:\n\n \(prompt)")
+        ))
+      ],
+      stream: true
+    )
+
+    for try await chunk in try await self.agents.createTurn(agent_id: self.agentId, session_id: self.agenticSystemSessionId, request: request) {
+      let payload = chunk.event.payload
+      switch (payload) {
+      case .step_start(_):
+        break
+      case .step_progress(let step):
+        DispatchQueue.main.async(execute: DispatchWorkItem {
+          withAnimation {
+            var message = messages.removeLast()
+            
+            if case .text(let delta) = step.delta {
+              message.text += "\(delta.text)"
+              self.actionItems += "\(delta.text)"
+            }
+            message.tokenCount += 2
+            message.dateUpdated = Date()
+            messages.append(message)
+          }
+        })
+      case .step_complete(_):
+        break
+      case .turn_start(_):
+        break
+      case .turn_complete(_):
+        break
+      case .turn_awaiting_input(_):
+        break
+      }
+    }
+  }
+
+  func callTools(prompt: String) async throws {
+    let request = Components.Schemas.CreateAgentTurnRequest(
+      messages: [
+        .UserMessage(Components.Schemas.UserMessage(
+          role: .user,
+          content: .case1("Call functions as needed to handle any actions in the following text:\n\n" + prompt)
+        ))
+      ],
+      stream: true
+    )
+
+    for try await chunk in try await self.agents.createTurn(agent_id: self.agentId, session_id: self.agenticSystemSessionId, request: request) {
+      let payload = chunk.event.payload
+      switch (payload) {
+      case .step_start(_):
+        break
+      case .step_progress(let step):
+          switch (step.delta) {
+          case .tool_call(let call):
+            if call.parse_status == .succeeded {
+              switch (call.tool_call) {
+              case .ToolCall(let toolCall):
+                  var args: [String : String] = [:]
+                  for (arg_name, arg) in toolCall.arguments.additionalProperties {
+                    switch (arg) {
+                    case .case1(let s):
+                      args[arg_name] = s
+                    case .case2(_), .case3(_), .case4(_), .case5(_), .case6(_):
+                      break
+                    }
+                  }
+
+                  let formatter = DateFormatter()
+                  formatter.dateFormat = "yyyy-MM-dd HH:mm"
+                  formatter.timeZone = TimeZone.current
+                  formatter.locale = Locale.current
+                  self.triggerAddEventToCalendar(
+                    title: args["event_name"]!,
+                    startDate: formatter.date(from: args["start"]!) ?? Date(),
+                    endDate: formatter.date(from: args["end"]!) ?? Date()
+                  )
+              case .case1(_):
+                break
+              }
+            }
+          case .text(let text):
+            break
+          case .image(_):
+            break
+          }
+        break
+      case .step_complete(_):
+        break
+      case .turn_start(_):
+        break
+      case .turn_complete(_):
+        break
+      case .turn_awaiting_input(_):
+        break
+      }
+    }
+  }
+
+  private func generate() {
+    guard !prompt.isEmpty else { return }
+    isGenerating = true
+
+    let text = prompt
+    prompt = ""
+    hideKeyboard()
+
+    runnerQueue.async {
+      defer {
+        DispatchQueue.main.async {
+          isGenerating = false
+        }
+      }
+
+      let bundle = Bundle.main
+      let modelPath = bundle.url(forResource: "llama3_2_spinquant_oct23", withExtension: "pte")?.relativePath
+      let tokenizerPath = bundle.url(forResource: "tokenizer", withExtension: "model")?.relativePath
+      inference.loadModel(
+        modelPath: modelPath!,
+        tokenizerPath: tokenizerPath!,
+        completion: {_ in }
+      )
+
+      Task {
+        messages.append(Message(text: text))
+
+        do {
+          let createSystemResponse = try await self.agents.create(
+            request: Components.Schemas.CreateAgentRequest(
+              agent_config: Components.Schemas.AgentConfig(
+                client_tools: [ CustomTools.getCreateEventToolForAgent() ],
+                max_infer_iters: 1,
+                model: "meta-llama/Llama-3.1-8B-Instruct",
+                instructions: "You are a helpful assistant",
+                enable_session_persistence: false
+              )
+            )
+          )
+          self.agentId = createSystemResponse.agent_id
+
+          let createSessionResponse = try await self.agents.createSession(agent_id: self.agentId, request: Components.Schemas.CreateAgentSessionRequest(session_name: "llama-assistant")
+          )
+          self.agenticSystemSessionId = createSessionResponse.session_id
+
+          messages.append(Message(type: .summary))
+          try await summarizeConversation(prompt: text)
+
+         messages.append(Message(type: .actionItems))
+         try await actionItems(prompt: text)
+
+         try await callTools(prompt: text)
+        } catch {
+          print("Error: \(error)")
+        }
+      }
+    }
+  }
+}
+
+extension View {
+  func hideKeyboard() {
+    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/EventEditView.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/EventEditView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import EventKit
+import EventKitUI
+
+struct EventEditView: UIViewControllerRepresentable {
+  @Binding var isPresented: Bool
+  let eventStore: EKEventStore
+  let event: EKEvent
+
+  func makeUIViewController(context: Context) -> EKEventEditViewController {
+    let controller = EKEventEditViewController()
+    controller.eventStore = eventStore
+    controller.event = event
+    controller.editViewDelegate = context.coordinator
+    return controller
+  }
+
+  func updateUIViewController(_ uiViewController: EKEventEditViewController, context: Context) {}
+
+  func makeCoordinator() -> Coordinator {
+    return Coordinator(isPresented: $isPresented)
+  }
+
+  class Coordinator: NSObject, EKEventEditViewDelegate {
+    @Binding var isPresented: Bool
+
+    init(isPresented: Binding<Bool>) {
+      _isPresented = isPresented
+    }
+
+    func eventEditViewController(_ controller: EKEventEditViewController, didCompleteWith action: EKEventEditViewAction) {
+      isPresented = false
+    }
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/Message.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/Message.swift
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import UIKit
+
+enum MessageType {
+  case prompted
+  case summary
+  case actionItems
+  case llavagenerated
+  case info
+}
+
+struct Message: Identifiable, Equatable {
+  let id = UUID()
+  let dateCreated = Date()
+  var dateUpdated = Date()
+  var type: MessageType = .prompted
+  var text = ""
+  var tokenCount = 0
+  var image: UIImage?
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/MessageListView.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/MessageListView.swift
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+struct MessageListView: View {
+  @Binding var messages: [Message]
+  @State private var showScrollToBottomButton = false
+  @State private var userHasScrolled = false
+  @State private var keyboardHeight: CGFloat = 0
+
+  var body: some View {
+    ScrollViewReader { value in
+      ScrollView {
+        VStack {
+          ForEach(messages) { message in
+            MessageView(message: message)
+              .padding([.leading, .trailing], 20)
+          }
+          GeometryReader { geometry -> Color in
+            DispatchQueue.main.async {
+              let maxY = geometry.frame(in: .global).maxY
+              let screenHeight = UIScreen.main.bounds.height - keyboardHeight
+              let isBeyondBounds = maxY > screenHeight - 50
+              if showScrollToBottomButton != isBeyondBounds {
+                showScrollToBottomButton = isBeyondBounds
+                userHasScrolled = isBeyondBounds
+              }
+            }
+            return Color.clear
+          }
+          .frame(height: 0)
+        }
+      }
+      .onChange(of: messages) {
+        if !userHasScrolled, let lastMessageId = messages.last?.id {
+          withAnimation {
+            value.scrollTo(lastMessageId, anchor: .bottom)
+          }
+        }
+      }
+      .overlay(
+        Group {
+          if false {
+            Button(action: {
+              withAnimation {
+                if let lastMessageId = messages.last?.id {
+                  value.scrollTo(lastMessageId, anchor: .bottom)
+                }
+                userHasScrolled = false
+              }
+            }) {
+              ZStack {
+                Circle()
+                  .fill(Color(UIColor.secondarySystemBackground).opacity(0.9))
+                  .frame(height: 28)
+                Image(systemName: "arrow.down.circle")
+                  .resizable()
+                  .aspectRatio(contentMode: .fit)
+                  .frame(height: 28)
+              }
+            }
+            .transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.2)))
+          }
+        },
+        alignment: .bottom
+      )
+    }
+    .onAppear {
+      NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { notification in
+        let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect ?? .zero
+        keyboardHeight = keyboardFrame.height - 40
+      }
+      NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
+        keyboardHeight = 0
+      }
+    }
+    .onDisappear {
+      NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+      NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/MessageView.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/MessageView.swift
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+struct MessageView: View {
+  let message: Message
+
+  var body: some View {
+    VStack(alignment: .center) {
+      if message.type == .info {
+        Text(message.text)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .padding([.leading, .trailing], 10)
+      } else {
+        VStack(alignment: message.type == .summary || message.type == .actionItems || message.type == .llavagenerated ? .leading : .trailing) {
+          if message.type == .summary || message.type == .actionItems || message.type == .llavagenerated || message.type == .prompted {
+            Text(message.type == .summary ? "Summary" : (message.type == .actionItems ? "Action Items" : "Prompt"))
+              .font(.caption)
+              .foregroundColor(.secondary)
+              .padding(message.type == .summary || message.type == .actionItems ? .trailing : .leading, 20)
+          }
+          HStack {
+            if message.type != .summary && message.type != .actionItems && message.type != .llavagenerated { Spacer() }
+            if message.text.isEmpty {
+              if let img = message.image {
+                Image(uiImage: img)
+                  .resizable()
+                  .scaledToFit()
+                  .frame(maxWidth: 200, maxHeight: 200)
+                  .padding()
+                  .background(Color.gray.opacity(0.2))
+                  .cornerRadius(8)
+                  .padding(.vertical, 2)
+              } else {
+                ProgressView()
+                  .progressViewStyle(CircularProgressViewStyle())
+              }
+            } else {
+              Text(message.text)
+                .padding(10)
+                .foregroundColor(message.type == .summary || message.type == .actionItems ? .primary : .white)
+                .background(message.type == .summary || message.type == .actionItems ? Color(UIColor.secondarySystemBackground) : Color.blue)
+                .cornerRadius(20)
+                .contextMenu {
+                  Button(action: {
+                    UIPasteboard.general.string = message.text
+                  }) {
+                    Text("Copy")
+                    Image(systemName: "doc.on.doc")
+                  }
+                }
+            }
+            if message.type == .summary || message.type == .actionItems { Spacer() }
+          }
+          let elapsedTime = message.dateUpdated.timeIntervalSince(message.dateCreated)
+        }.padding([.leading, .trailing], message.type == .info ? 0 : 10)
+      }
+    }
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/iOSCalendarAssistantApp.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf/iOSCalendarAssistantApp.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+@main
+struct iOSCalendarAssistantApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/examples/ios_quick_demo/README.md
+++ b/examples/ios_quick_demo/README.md
@@ -1,0 +1,96 @@
+# iOSQuickDemo
+
+iOSQuickDemo is a demo app ([video](https://drive.google.com/file/d/1HnME3VmsYlyeFgsIOMlxZy5c8S2xP4r4/view?usp=sharing)) that shows how to use the Llama Stack Swift SDK ([repo](https://github.com/meta-llama/llama-stack-client-swift)) and its `ChatCompletionRequest` API with a remote Llama Stack server to perform remote inference with Llama 3.1.
+
+## Installation
+
+The quickest way to try out the demo for remote inference is using Together.ai's Llama Stack distro at https://llama-stack.together.ai - you can skip the next section and go to the Build and Run the iOS demo section directly.
+
+## (Optional) Build and Run Own Llama Stack Distro
+
+You need to set up a remote Llama Stack distributions to run this demo. Assuming you have a [Fireworks](https://fireworks.ai/account/api-keys) or [Together](https://api.together.ai/) API key, which you can get easily by clicking the link above:
+
+```
+conda create -n llama-stack python=3.10
+conda activate llama-stack
+pip install --no-cache llama-stack==0.1.3 llama-models==0.1.3 llama-stack-client==0.1.3
+```
+
+Then, either:
+```
+PYPI_VERSION=0.1.3 llama stack build --template fireworks --image-type conda
+export FIREWORKS_API_KEY="<your_fireworks_api_key>"
+llama stack run fireworks
+```
+or
+```
+PYPI_VERSION=0.1.3 llama stack build --template together --image-type conda
+export TOGETHER_API_KEY="<your_together_api_key>"
+llama stack run together
+```
+
+The default port is 5000 for `llama stack run` and you can specify a different port by adding `--port <your_port>` to the end of `llama stack run fireworks|together`.
+
+## Build and Run the iOS demo
+
+1. Double click `iOSQuickDemo/iOSQuickDemo.xcodeproj` to open it in Xcode.
+
+2. Under the iOSQuickDemo project - Package Dependencies, click the + sign, then add `https://github.com/meta-llama/llama-stack-client-swift` at the top right and 0.1.3 in the Dependency Rule, then click Add Package.
+
+![](quick1.png)
+![](quick2.png)
+
+3. (Optional) Replace the `RemoteInference` url string in `ContentView.swift` below with the host IP and port of the remote Llama Stack distro in Build and Run Own Llama Stack Distro:
+
+```
+let inference = RemoteInference(url: URL(string: "https://llama-stack.together.ai")!)
+```
+
+**Note:** In order for the app to access the remote URL, the app's `Info.plist` needs to have the entry `App Transport Security Settings` with `Allow Arbitrary Loads` set to YES.
+
+4. Build the run the app on an iOS simulator or your device. Then click the Inference button, optionally after entering your own Question, to see the Llama answer. See the demo video [here](https://drive.google.com/file/d/1HnME3VmsYlyeFgsIOMlxZy5c8S2xP4r4/view?usp=sharing).
+
+
+## Implementation Note
+
+The Llama Stack `chatCompletion` API is used for the inference. Its paramater `request` requires three parameters: a list of messages, the model id, and the stream setting. A `UserMessage`'s `content` contains the user text input inside `TextContentItem`.
+
+Inside the async return of the `chatCompletion`, each returned text chunk is appended to the message as the answer to the user input question.
+
+```swift
+for await chunk in try await inference.chatCompletion(
+    request:
+        Components.Schemas.ChatCompletionRequest(
+        model_id: "meta-llama/Llama-3.1-8B-Instruct",
+        messages: [
+            .user(
+            Components.Schemas.UserMessage(
+                role: .user,
+                content:
+                    .InterleavedContentItem(
+                        .text(Components.Schemas.TextContentItem(
+                            _type: .text,
+                            text: userInput
+                        )
+                    )
+                )
+            )
+        )
+        ],
+        stream: true)
+    ) {
+        switch (chunk.event.delta) {
+        case .text(let s):
+            message += s.text
+            break
+        case .image(let s):
+            print("> \(s)")
+            break
+        case .tool_call(let s):
+            print("> \(s)")
+            break
+        }
+    }
+```
+
+For a more advanced demo using the Llama Stack Agent API and custom tool calling feature, see the [iOS Calendar Assistant demo](https://github.com/meta-llama/llama-stack-apps/tree/main/examples/ios_calendar_assistant).

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo.xcodeproj/project.pbxproj
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,441 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BA2687CD2D7A745000F7058A /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 26AF95862D3D74A000168181 /* LlamaStackClient */; };
+		BA2687CE2D7A745000F7058A /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 26F9B8EE2D3D76A4009E42C7 /* LlamaStackClient */; };
+		BA2687CF2D7A745000F7058A /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 26F9B8F12D3D7718009E42C7 /* LlamaStackClient */; };
+		BA2687D02D7A745000F7058A /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 26F9B8FD2D3D7879009E42C7 /* LlamaStackClient */; };
+		BA2687D12D7A745000F7058A /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 26DF73172D3D7F7300D52D27 /* LlamaStackClient */; };
+		BA2687D22D7A745000F7058A /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 26C2EA212D3D7FD4000FD42D /* LlamaStackClient */; };
+		BA2687D32D7A745000F7058A /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 26F399262D42F0E3007FB9D6 /* LlamaStackClient */; };
+		BA2687D42D7A745000F7058A /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 265029162D4306A200D06225 /* LlamaStackClient */; };
+		BA2687D52D7A745000F7058A /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 265029512D46A19A00D06225 /* LlamaStackClient */; };
+		BA2687E32D7A751A00F7058A /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = BA2687E22D7A751A00F7058A /* LlamaStackClient */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		26AF95742D3D743800168181 /* iOSQuickDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSQuickDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		26C2EA242D3D8303000FD42D /* Exceptions for "iOSQuickDemo" folder in "iOSQuickDemo" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 26AF95732D3D743800168181 /* iOSQuickDemo */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		26AF95762D3D743800168181 /* iOSQuickDemo */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				26C2EA242D3D8303000FD42D /* Exceptions for "iOSQuickDemo" folder in "iOSQuickDemo" target */,
+			);
+			path = iOSQuickDemo;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		26AF95712D3D743800168181 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BA2687D52D7A745000F7058A /* LlamaStackClient in Frameworks */,
+				BA2687D42D7A745000F7058A /* LlamaStackClient in Frameworks */,
+				BA2687D32D7A745000F7058A /* LlamaStackClient in Frameworks */,
+				BA2687D22D7A745000F7058A /* LlamaStackClient in Frameworks */,
+				BA2687D12D7A745000F7058A /* LlamaStackClient in Frameworks */,
+				BA2687D02D7A745000F7058A /* LlamaStackClient in Frameworks */,
+				BA2687E32D7A751A00F7058A /* LlamaStackClient in Frameworks */,
+				BA2687CF2D7A745000F7058A /* LlamaStackClient in Frameworks */,
+				BA2687CE2D7A745000F7058A /* LlamaStackClient in Frameworks */,
+				BA2687CD2D7A745000F7058A /* LlamaStackClient in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		26AF956B2D3D743800168181 = {
+			isa = PBXGroup;
+			children = (
+				26AF95762D3D743800168181 /* iOSQuickDemo */,
+				26F399242D42F0AB007FB9D6 /* Frameworks */,
+				26AF95752D3D743800168181 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		26AF95752D3D743800168181 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				26AF95742D3D743800168181 /* iOSQuickDemo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		26F399242D42F0AB007FB9D6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		26AF95732D3D743800168181 /* iOSQuickDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 26AF95822D3D743A00168181 /* Build configuration list for PBXNativeTarget "iOSQuickDemo" */;
+			buildPhases = (
+				26AF95702D3D743800168181 /* Sources */,
+				26AF95712D3D743800168181 /* Frameworks */,
+				26AF95722D3D743800168181 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				26AF95762D3D743800168181 /* iOSQuickDemo */,
+			);
+			name = iOSQuickDemo;
+			packageProductDependencies = (
+				26AF95862D3D74A000168181 /* LlamaStackClient */,
+				26F9B8EE2D3D76A4009E42C7 /* LlamaStackClient */,
+				26F9B8F12D3D7718009E42C7 /* LlamaStackClient */,
+				26F9B8FD2D3D7879009E42C7 /* LlamaStackClient */,
+				26DF73172D3D7F7300D52D27 /* LlamaStackClient */,
+				26C2EA212D3D7FD4000FD42D /* LlamaStackClient */,
+				26F399262D42F0E3007FB9D6 /* LlamaStackClient */,
+				265029162D4306A200D06225 /* LlamaStackClient */,
+				265029512D46A19A00D06225 /* LlamaStackClient */,
+				BA2687E22D7A751A00F7058A /* LlamaStackClient */,
+			);
+			productName = iOSQuickDemo;
+			productReference = 26AF95742D3D743800168181 /* iOSQuickDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		26AF956C2D3D743800168181 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1620;
+				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+					26AF95732D3D743800168181 = {
+						CreatedOnToolsVersion = 16.2;
+					};
+				};
+			};
+			buildConfigurationList = 26AF956F2D3D743800168181 /* Build configuration list for PBXProject "iOSQuickDemo" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 26AF956B2D3D743800168181;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				BA2687E12D7A751A00F7058A /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 26AF95752D3D743800168181 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				26AF95732D3D743800168181 /* iOSQuickDemo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		26AF95722D3D743800168181 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		26AF95702D3D743800168181 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		26AF95802D3D743A00168181 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		26AF95812D3D743A00168181 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		26AF95832D3D743A00168181 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"iOSQuickDemo/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iOSQuickDemo/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = llama.iOSQuickDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		26AF95842D3D743A00168181 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"iOSQuickDemo/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iOSQuickDemo/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = llama.iOSQuickDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		26AF956F2D3D743800168181 /* Build configuration list for PBXProject "iOSQuickDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				26AF95802D3D743A00168181 /* Debug */,
+				26AF95812D3D743A00168181 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		26AF95822D3D743A00168181 /* Build configuration list for PBXNativeTarget "iOSQuickDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				26AF95832D3D743A00168181 /* Debug */,
+				26AF95842D3D743A00168181 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BA2687E12D7A751A00F7058A /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/meta-llama/llama-stack-client-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		265029162D4306A200D06225 /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LlamaStackClient;
+		};
+		265029512D46A19A00D06225 /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LlamaStackClient;
+		};
+		26AF95862D3D74A000168181 /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LlamaStackClient;
+		};
+		26C2EA212D3D7FD4000FD42D /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LlamaStackClient;
+		};
+		26DF73172D3D7F7300D52D27 /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LlamaStackClient;
+		};
+		26F399262D42F0E3007FB9D6 /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LlamaStackClient;
+		};
+		26F9B8EE2D3D76A4009E42C7 /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LlamaStackClient;
+		};
+		26F9B8F12D3D7718009E42C7 /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LlamaStackClient;
+		};
+		26F9B8FD2D3D7879009E42C7 /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LlamaStackClient;
+		};
+		BA2687E22D7A751A00F7058A /* LlamaStackClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BA2687E12D7A751A00F7058A /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */;
+			productName = LlamaStackClient;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 26AF956C2D3D743800168181 /* Project object */;
+}

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,105 @@
+{
+  "originHash" : "df038bcc9f4c58946ce49e72295f54d7068f7de8d60780a55423d96d21e68a16",
+  "pins" : [
+    {
+      "identity" : "llama-stack-client-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/meta-llama/llama-stack-client-swift",
+      "state" : {
+        "revision" : "fafb0cf96b1b51098e09dca9547a4680da274d25",
+        "version" : "0.1.4"
+      }
+    },
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit",
+      "state" : {
+        "revision" : "90c137c3dfde4e31204ffccc51a0a17a959efde7",
+        "version" : "3.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "ef18d829e8b92d731ad27bb81583edd2094d1ce3",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-openapi-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-generator",
+      "state" : {
+        "revision" : "84b693f9d0559dc488e691edb4837bafbce2aaea",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime.git",
+      "state" : {
+        "revision" : "23146bc8710ac5e57abb693113f02dc274cf39b6",
+        "version" : "1.8.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-urlsession",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-urlsession.git",
+      "state" : {
+        "revision" : "9bf4c712ad7989d6a91dbe68748b8829a50837e4",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "b4b8042411dc7bbb696300a34a4bf3ba1b7ad19b",
+        "version" : "5.3.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/Assets.xcassets/Contents.json
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/ContentView.swift
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/ContentView.swift
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+import LlamaStackClient
+
+struct ContentView: View {
+  @State private var message: String = ""
+  @State private var userInput: String = "Best quotes in Godfather"
+
+  private let runnerQueue = DispatchQueue(label: "org.llamastack.iosquickdemo")
+
+  var body: some View {
+    VStack(spacing: 20) {
+      ScrollView {
+        Text(message.isEmpty ? "Click Inference to see Llama's answer" : message)
+          .font(.headline)
+          .foregroundColor(.blue)
+          .padding()
+          .frame(maxWidth: .infinity)
+          .background(Color.gray.opacity(0.2))
+          .cornerRadius(8)
+      }
+      .frame(maxHeight: 500)
+
+      VStack(alignment: .leading, spacing: 10) {
+        Text("Question")
+            .font(.headline)
+
+        TextField("Enter your question here", text: $userInput)
+            .textFieldStyle(RoundedBorderTextFieldStyle())
+            .padding()
+      }
+
+      Button(action: {
+          handleButtonClick(buttonName: "Inference")
+      }) {
+          Text("Inference")
+              .font(.title2)
+              .foregroundColor(.white)
+              .padding()
+              .frame(maxWidth: .infinity)
+              .background(Color.green)
+              .cornerRadius(8)
+      }
+
+      Spacer()
+    }
+    .padding()
+  }
+
+  private func handleButtonClick(buttonName: String) {
+    if userInput.isEmpty {
+      message = "Please enter a question before clicking 'Inference'."
+      return
+    }
+
+    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    
+    message = ""
+
+    let workItem = DispatchWorkItem {
+      defer {
+        DispatchQueue.main.async {
+        }
+      }
+
+      Task {
+
+        // replace the URL string if you build and run your own Llama Stack distro as shown in https://github.com/meta-llama/llama-stack-apps/tree/main/examples/ios_quick_demo#optional-build-and-run-own-llama-stack-distro
+        let inference = RemoteInference(url: URL(string: "https://llama-stack.together.ai")!)
+
+        do {
+          for await chunk in try await inference.chatCompletion(
+            request:
+              Components.Schemas.ChatCompletionRequest(
+                model_id: "meta-llama/Llama-3.1-8B-Instruct",
+                messages: [
+                  .user(
+                    Components.Schemas.UserMessage(
+                      role: .user,
+                      content:
+                          .InterleavedContentItem(
+                              .text(Components.Schemas.TextContentItem(
+                                  _type: .text,
+                                  text: userInput
+                              )
+                          )
+                      )
+                  )
+                )
+              ],
+              stream: true)
+          ) {
+            switch (chunk.event.delta) {
+            case .text(let s):
+              message += s.text
+              break
+            case .image(let s):
+              print("> \(s)")
+              break
+            case .tool_call(let s):
+              print("> \(s)")
+              break
+            }
+          }
+        }
+        catch {
+          print("Error: \(error)")
+        }
+      }
+    }
+
+    runnerQueue.async(execute: workItem)
+  }
+}

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/Info.plist
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/iOSQuickDemoApp.swift
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/iOSQuickDemoApp.swift
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+@main
+struct iOSQuickDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
To help consolidate the example code, we are moving the iOS demo apps from https://github.com/meta-llama/llama-stack-apps/tree/main/examples to this Swift SDK repo.
- ios_calendar_assistant (local and remote)
- ios_quick_demo